### PR TITLE
Route authtoken migrations to local module

### DIFF
--- a/app-main/app/settings.py
+++ b/app-main/app/settings.py
@@ -96,6 +96,11 @@ INSTALLED_APPS = [
 ]
 
 
+MIGRATION_MODULES = {
+    'authtoken': 'app_mod.authtoken_migrations',
+}
+
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/app-main/app_mod/authtoken_migrations/0001_initial.py
+++ b/app-main/app_mod/authtoken_migrations/0001_initial.py
@@ -1,0 +1,9 @@
+"""Proxy module for the upstream authtoken 0001 migration."""
+
+from importlib import import_module
+
+Migration = import_module(
+    "rest_framework.authtoken.migrations.0001_initial"
+).Migration
+
+__all__ = ["Migration"]

--- a/app-main/app_mod/authtoken_migrations/0002_auto_20160226_1747.py
+++ b/app-main/app_mod/authtoken_migrations/0002_auto_20160226_1747.py
@@ -1,0 +1,9 @@
+"""Proxy module for the upstream authtoken 0002 migration."""
+
+from importlib import import_module
+
+Migration = import_module(
+    "rest_framework.authtoken.migrations.0002_auto_20160226_1747"
+).Migration
+
+__all__ = ["Migration"]

--- a/app-main/app_mod/authtoken_migrations/0003_tokenproxy.py
+++ b/app-main/app_mod/authtoken_migrations/0003_tokenproxy.py
@@ -1,0 +1,9 @@
+"""Proxy module for the upstream authtoken 0003 migration."""
+
+from importlib import import_module
+
+Migration = import_module(
+    "rest_framework.authtoken.migrations.0003_tokenproxy"
+).Migration
+
+__all__ = ["Migration"]

--- a/app-main/app_mod/authtoken_migrations/0004_alter_tokenproxy_options.py
+++ b/app-main/app_mod/authtoken_migrations/0004_alter_tokenproxy_options.py
@@ -1,0 +1,9 @@
+"""Proxy module for the upstream authtoken 0004 migration."""
+
+from importlib import import_module
+
+Migration = import_module(
+    "rest_framework.authtoken.migrations.0004_alter_tokenproxy_options"
+).Migration
+
+__all__ = ["Migration"]

--- a/app-main/app_mod/authtoken_migrations/0005_alter_token_key.py
+++ b/app-main/app_mod/authtoken_migrations/0005_alter_token_key.py
@@ -1,0 +1,22 @@
+"""Alter the authtoken key length to support extended tokens."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("authtoken", "0004_alter_tokenproxy_options"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="token",
+            name="key",
+            field=models.CharField(
+                max_length=255,
+                primary_key=True,
+                serialize=False,
+                verbose_name="Key",
+            ),
+        ),
+    ]

--- a/app-main/app_mod/authtoken_migrations/__init__.py
+++ b/app-main/app_mod/authtoken_migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Custom migration module proxying rest_framework.authtoken migrations."""


### PR DESCRIPTION
## Summary
- override the authtoken migration module so Django stores migrations within the project tree
- proxy the upstream Django REST Framework authtoken migrations and add a local migration that widens the token key to 255 characters to match the custom token model

## Testing
- python manage.py makemigrations
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d139aa0ae8832c85254011b8b0245b