### PR TITLE
Add admin utility script execution view

### DIFF
--- a/app-main/templates/admin/base.html
+++ b/app-main/templates/admin/base.html
@@ -52,6 +52,7 @@
                     {% if docsroot %}
                         <a href="{{ docsroot }}">{% translate 'Documentation' %}</a> /
                     {% endif %}
+                    <a href="{% url 'admin:utility-scripts' %}">{% translate 'Utility scripts' %}</a> /
                 {% endif %}
                 {% if user.has_usable_password %}
                 <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /

--- a/app-main/templates/admin/utility_scripts.html
+++ b/app-main/templates/admin/utility_scripts.html
@@ -1,0 +1,57 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Utility scripts" %}{% endblock %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; {% trans 'Utility scripts' %}
+  </div>
+{% endblock %}
+
+{% block content %}
+  <h1>{% trans "Utility scripts" %}</h1>
+  <p class="help">
+    {% blocktrans %}Use these actions to execute scripts from <code>app-main/utils</code>. Output is shown as an admin message after the script finishes.{% endblocktrans %}
+  </p>
+  <p class="help">
+    {% blocktrans %}Be cautious—many scripts interact directly with external systems or the production database.{% endblocktrans %}
+  </p>
+  <div class="module">
+    <table class="admin-utility-table">
+      <thead>
+        <tr>
+          <th scope="col">{% trans "Name" %}</th>
+          <th scope="col">{% trans "File" %}</th>
+          <th scope="col">{% trans "Description" %}</th>
+          <th scope="col">{% trans "Run" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for script in scripts %}
+          <tr>
+            <th scope="row">{{ script.display_name }}</th>
+            <td><code>{{ script.filename }}</code></td>
+            <td>
+              {% if script.doc %}
+                <span class="script-doc">{{ script.doc|linebreaksbr }}</span>
+              {% else %}
+                <span class="quiet">{% trans "No description available." %}</span>
+              {% endif %}
+            </td>
+            <td class="actions">
+              <form method="post" action="{% url 'admin:run-utility-script' script.slug %}">
+                {% csrf_token %}
+                <button type="submit" class="button default">{% trans "Run" %}</button>
+              </form>
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="4" class="quiet">{% trans "No scripts were found in app-main/utils." %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an admin-only view that lists utility scripts and allows triggering their `run()` entry point
- capture stdout/stderr from the scripts, report results via admin messages, and expose the page through the admin navigation
- build a dedicated template that documents the scripts and presents one-click execution forms

## Testing
- `python app-main/manage.py check` *(fails: missing Django runtime in container)*
- `python -m compileall app-main/myview/admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68d14d1982bc832c97b087f7d44eeda4