### PR TITLE
Add detailed Coolify deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,21 @@ developing.
 
 ## Deploying with Coolify + Traefik
 
-Coolify can build and run the application directly from this repository using the provided `Dockerfile` and
-`docker-compose.coolify.yml` compose descriptor. The compose file wires the Django container to PostgreSQL, exposes the
-Gunicorn service to Traefik, and provisions persistent volumes for static and media assets.
+A detailed, step-by-step deployment walkthrough is available in
+[`docs/coolify-deployment-guide.md`](docs/coolify-deployment-guide.md). In summary, Coolify can build and run the application
+directly from this repository using the provided `Dockerfile` and `docker-compose.coolify.yml` compose descriptor. The compose
+file wires the Django container to PostgreSQL, exposes the Gunicorn service to Traefik, and provisions persistent volumes for
+static and media assets.
 
-1. Create a copy of `.env.example` named `.env` and fill in the values (or add the same key/value pairs as environment
-   variables in Coolify). Pay particular attention to `DJANGO_SECRET`, `POSTGRES_*`, and `TRAEFIK_*` values.
-2. In Coolify, create a "Docker Compose" application pointing to this repository and select `docker-compose.coolify.yml` as the
-   compose file. The default labels assume Traefik uses the `coolify-network` overlay and the `websecure` entrypoint—override
-   the `TRAEFIK_*` variables if your installation differs.
-3. Coolify will build the image from `Dockerfile`, run database migrations, collect static assets, and expose the site through
-   Traefik on the hostname configured by `TRAEFIK_HOST`.
+At a minimum you will:
+
+1. Copy `.env.example` to `.env` (or paste the same key/value pairs into Coolify) and provide values for `DJANGO_SECRET`, the
+   `POSTGRES_*` credentials, `TRAEFIK_*` routing metadata, and any integration secrets you require.
+2. Create a Coolify **Docker Compose** application that points to this repository and select `docker-compose.coolify.yml` as the
+   compose file. The default Traefik labels expect the external network to be called `coolify-network` with a `websecure`
+   entrypoint—override the variables if your installation differs.
+3. Deploy the stack. Coolify will build the image from `Dockerfile`, run database migrations and `collectstatic` via
+   `docker/entrypoint.sh`, and expose the site through Traefik on the hostname configured by `TRAEFIK_HOST`.
 
 To run the same stack locally without Coolify:
 

--- a/docs/coolify-deployment-guide.md
+++ b/docs/coolify-deployment-guide.md
@@ -1,0 +1,79 @@
+# Coolify Deployment Guide
+
+This guide walks through deploying the API Security Django application to a self-hosted [Coolify](https://coolify.io/) instance. Coolify uses Docker Compose behind the scenes, so the repository ships with everything you need for a reproducible deployment.
+
+## 1. Prerequisites
+
+Before you begin, make sure you have:
+
+- A running Coolify v3+ installation with access to the **Docker Compose** application type.
+- Traefik configured as Coolify's reverse proxy (Coolify sets this up automatically). Have an FQDN ready and pointed at your Coolify host via DNS.
+- SSH access or a Git integration (GitHub, GitLab, Bitbucket, or a generic Git URL) so Coolify can pull this repository.
+- Application secrets, directory credentials, and API tokens for the data sources you plan to use (see [Environment variables](#2-prepare-environment-variables)).
+
+## 2. Prepare environment variables
+
+The project reads its configuration from environment variables. Copy `.env.example` in the repository to `.env` to review the available settings and gather the values you will need. In Coolify you will create the same keys under **Settings → Environment Variables** for the application.
+
+At minimum set the following values:
+
+| Variable | Purpose |
+| --- | --- |
+| `DJANGO_SECRET` | A long random string used for Django's cryptographic signing. |
+| `DJANGO_ALLOWED_HOSTS` / `DJANGO_CSRF_TRUSTED_ORIGINS` | Should match the public hostname you will expose via Traefik. |
+| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Credentials for the bundled PostgreSQL database service. |
+| `TRAEFIK_HOST` | FQDN that Traefik should route to this application. |
+| `TRAEFIK_NETWORK`, `TRAEFIK_ENTRYPOINT`, `TRAEFIK_CERTRESOLVER` | Networking metadata; defaults match a standard Coolify install. Override if your Traefik setup differs. |
+| `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_PASSWORD` | Credentials you will use to create an administrative user after deployment. |
+
+All of the other entries in `.env.example` are optional or relate to integrations (Azure AD, SCCM, Microsoft Defender, OpenAI, etc.). Populate them as needed for your environment.
+
+> **Tip:** Leave `DJANGO_DEBUG=false` in production and keep `DJANGO_SESSION_COOKIE_SECURE`, `DJANGO_CSRF_COOKIE_SECURE`, and `DJANGO_SECURE_SSL_REDIRECT` set to `true` to enforce HTTPS-only cookies.
+
+## 3. Add the application in Coolify
+
+1. In Coolify, click **New Application → Docker Compose**.
+2. Choose the Git provider and repository that hosts this project, then select the branch you want to deploy (typically `main`).
+3. When prompted for the compose file path, enter `docker-compose.coolify.yml`. Leave the working directory as `/` unless you have the repository nested deeper.
+4. Coolify will detect the services defined in the compose file:
+   - `web`: Builds from the repository `Dockerfile`, runs Gunicorn on port `8121`, and exposes the Django app. It mounts persistent volumes for `/data/static` and `/data/media`.
+   - `db`: Uses the official `postgres:16` image with a persistent volume for the database cluster.
+5. Under the **Environment Variables** tab, add the keys discussed above (copy/paste from your `.env`). You can bulk import by pasting the contents of your `.env` file.
+6. Ensure the Traefik network name matches your setup. By default the compose file expects an external network named `coolify-network`. Adjust the `TRAEFIK_NETWORK` variable if your Traefik network is different, or create the network beforehand (Coolify creates `coolify-network` automatically when Traefik is enabled).
+
+## 4. First deployment
+
+1. Click **Deploy**. Coolify will:
+   - Build the application image using the provided `Dockerfile` (installs system packages, Python dependencies, and copies the project code).
+   - Launch PostgreSQL and wait for it to become healthy.
+   - Start the Django container, which runs `manage.py migrate` and `collectstatic` automatically via `docker/entrypoint.sh`.
+2. Watch the deployment logs to ensure migrations complete successfully and that Gunicorn is listening on port `8121`.
+3. Once Traefik provisions a certificate and routes traffic, browse to `https://<your-domain>` to confirm the site is online.
+
+## 5. Create an administrative user
+
+If no superuser exists yet, open the Coolify application page, go to the **Actions → Execute Command** menu for the `web` service, and run:
+
+```bash
+python manage.py createsuperuser --username "$DJANGO_SUPERUSER_USERNAME" --email you@example.com
+```
+
+Provide the same password you configured in the environment variables when prompted. You can now log in to the admin interface and configure integrations.
+
+## 6. Ongoing management
+
+- **Updating the application:** Push new commits to the tracked branch and trigger a redeploy in Coolify. The entrypoint will re-run migrations and collect static assets as needed.
+- **Running management commands:** Use Coolify's “Execute Command” feature on the `web` container to run scripts such as `python manage.py shell` or custom management commands.
+- **Backups:** The compose file defines named volumes (`postgres_data`, `static_data`, `media_data`). Configure backups for these volumes in your Coolify host to protect database and media content.
+
+## 7. Local smoke test (optional)
+
+You can rehearse the deployment locally with Docker Compose to verify your configuration before pushing to production:
+
+```bash
+cp .env.example .env
+# Edit .env with the values you plan to use
+docker compose -f docker-compose.coolify.yml up --build
+```
+
+The stack will come up exactly as Coolify orchestrates it, so you can validate migrations, networking, and integrations ahead of time.


### PR DESCRIPTION
## Summary
- add a dedicated Coolify deployment guide covering prerequisites, environment variables, first deploy, and ongoing management
- link the README Coolify section to the new guide and highlight the key deployment steps

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d14edcb154832cb48a9e82a86b1731