### PR TITLE
Document network creation requirement for Coolify deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ At a minimum you will:
    `POSTGRES_*` credentials, `TRAEFIK_*` routing metadata, and any integration secrets you require.
 2. Create a Coolify **Docker Compose** application that points to this repository and select `docker-compose.coolify.yml` as the
    compose file. The default Traefik labels expect the external network to be called `coolify-network` with a `websecure`
-   entrypoint—override the variables if your installation differs.
+   entrypoint—override the variables if your installation differs. If your Coolify host does not already have that network, SSH
+   into the host once and run `docker network create coolify-network` (or set `TRAEFIK_NETWORK` to the Traefik network name you
+   actually use) before triggering a deployment.
 3. Deploy the stack. Coolify will build the image from `Dockerfile`, run database migrations and `collectstatic` via
    `docker/entrypoint.sh`, and expose the site through Traefik on the hostname configured by `TRAEFIK_HOST`.
 

--- a/docs/coolify-deployment-guide.md
+++ b/docs/coolify-deployment-guide.md
@@ -80,3 +80,23 @@ docker compose -f docker-compose.coolify.yml up --build
 
 If you already have a differently named Traefik network, skip the `docker network create` command and export `TRAEFIK_NETWORK=<your-network>` before running Compose. The stack will come up exactly as Coolify orchestrates it, so you can validate migrations, networking, and integrations ahead of time.
 
+## 8. Troubleshooting
+
+### `network coolify-network declared as external, but could not be found`
+
+This error appears when Docker cannot find the Traefik network referenced by the compose file. On Coolify hosts the network is
+usually created automatically, but if you see this message:
+
+```
+network coolify-network declared as external, but could not be found
+```
+
+SSH into the Coolify server and create the network once:
+
+```bash
+docker network create coolify-network
+```
+
+If your Traefik installation uses a different network name, set the `TRAEFIK_NETWORK` environment variable in Coolify to that
+name instead of creating `coolify-network`.
+


### PR DESCRIPTION
## Summary
- document that the Traefik network must exist before deploying via Coolify
- add troubleshooting guidance for the "network coolify-network" error in the Coolify deployment guide

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d156b11e34832ca16afa44d71aa4db