### PR TITLE
Update Coolify compose network configuration

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -65,5 +65,5 @@ networks:
   internal:
     driver: bridge
   traefik:
-    external: true
     name: ${TRAEFIK_NETWORK:-coolify-network}
+    driver: bridge


### PR DESCRIPTION
## Summary
- change the Traefik network definition so docker-compose can create the network automatically when it is missing

## Testing
- docker compose -f docker-compose.coolify.yml config *(fails: `docker` command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d15814825c832cb244166ea6cc99d3