### PR TITLE
Ensure AD group associations auto-sync members

### DIFF
--- a/app-main/myview/admin.py
+++ b/app-main/myview/admin.py
@@ -75,12 +75,13 @@ try:
             return self.readonly_fields
         
         def save_model(self, request, obj, form, change):
-            # Your custom logic here
-            from myview.models import ADGroupAssociation
-
-            ADGroupAssociation.sync_ad_group_members(obj)
-
+            # Persist the object before attempting to sync members so that the
+            # many-to-many relation can be updated safely. Newly created
+            # instances trigger their sync inside the model's save method.
             super().save_model(request, obj, form, change)
+
+            if change:
+                obj.sync_ad_group_members()
         def member_count(self, obj):
             return obj.members.count()
         member_count.short_description = 'Member Count'


### PR DESCRIPTION
## Summary
- sync AD group members immediately after saving new ADGroupAssociation records
- avoid pre-save syncing in the admin so membership updates run after the association exists

## Testing
- `python manage.py check` *(fails: Django not installed in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66f7ed790832c8f2cf2c8ad9e2bdc