### PR TITLE
Normalize AD usernames during sync

### DIFF
--- a/app-main/app/scripts/create_or_update_django_user.py
+++ b/app-main/app/scripts/create_or_update_django_user.py
@@ -6,6 +6,9 @@ def create_or_update_django_user(username, first_name, last_name, email, is_supe
     try:
         if not username:
             raise ValueError("username cannot be null or empty")
+        # Store usernames in lowercase to avoid case-sensitive mismatches
+        # when syncing memberships from Active Directory.
+        username = username.lower()
         from django.contrib.auth.models import User
         existing_user = User.objects.filter(username=username).first()
         if existing_user:

--- a/app-main/myview/models.py
+++ b/app-main/myview/models.py
@@ -175,7 +175,9 @@ class ADGroupAssociation(BaseModel):
                     raise ValueError(f"User {user_principal_name} is not synched with on-premise users")
 
                 # Create new user if the user is synched with azure ad
-                username = sam_accountname
+                # Normalize the username to lowercase so that it matches the
+                # representation used when linking users to AD groups later.
+                username = sam_accountname.lower()
                 first_name = user.get('givenName', [''])[0]
                 last_name = user.get('sn', [''])[0]
                 email = user_principal_name


### PR DESCRIPTION
## Summary
- ensure new AD users are created with lowercase usernames so membership lookups succeed
- normalize usernames before creating or updating Django users when syncing AD memberships

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d671d8d280832c9831f45e68b73949