### PR TITLE
Fix logging configuration for Django log file

### DIFF
--- a/app-main/app/settings.py
+++ b/app-main/app/settings.py
@@ -332,6 +332,9 @@ SWAGGER_SETTINGS = {
 
 LOGIN_URL='/login/'
 
+LOG_DIR = PROJECT_ROOT / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -350,7 +353,7 @@ LOGGING = {
         'file': {
             'level': 'DEBUG',  # Set to DEBUG to capture everything in the log file
             'class': 'logging.FileHandler',
-            'filename': '/usr/src/project/app-main/django.log',
+            'filename': str(LOG_DIR / 'django.log'),
             'formatter': 'verbose',
         },
     },


### PR DESCRIPTION
## Summary
- ensure the logging directory exists before configuring handlers
- use a project-relative path for the Django log file

## Testing
- `python app-main/manage.py check` *(fails: Django is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da47a8bf1c832ca34c89ecba31b076