### PR TITLE
Fix missing pkg_resources dependency for drf-yasg

### DIFF
--- a/app-main/requirements.txt
+++ b/app-main/requirements.txt
@@ -60,6 +60,7 @@ python-dotenv==1.0.1
 pytz==2024.1
 PyYAML==6.0.1
 requests==2.32.0
+setuptools==70.0.0
 six==1.16.0
 sniffio==1.3.1
 sqlparse==0.5.0


### PR DESCRIPTION
## Summary
- add setuptools to the Django app requirements so pkg_resources is available for drf-yasg during startup

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da4a750f14832ca9a5066a0479f433