### PR TITLE
Set devcontainer git identity defaults

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,10 @@
     "service": "xx-api-security-ait-dtu-dk-app-main",
     "workspaceFolder": "/app",
     "remoteUser": "django",
+    "containerEnv": {
+        "DEVCONTAINER_GITHUB_NAME": "Victor Reipur",
+        "DEVCONTAINER_GITHUB_EMAIL": "vicre@dtu.dk"
+    },
     "customizations": {
         "vscode": {
             "settings": {


### PR DESCRIPTION
## Summary
- define container-level environment variables for the Git identity so the post-start script configures git using the desired values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7f0d3294832c99785bdbc77a137d