### PR TITLE
Auto-refresh API endpoint definitions at startup

### DIFF
--- a/app-main/myview/apps.py
+++ b/app-main/myview/apps.py
@@ -1,17 +1,22 @@
-
 from django.apps import AppConfig
-from django.core.management import call_command
 import logging
 
+
 logger = logging.getLogger(__name__)
+
 
 class MyviewConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'myview'
 
-
     def ready(self):
-        # Best-effort background sync of AD groups at startup and after migrations
+        self._register_ad_group_sync()
+        self._register_endpoint_refresh()
+        self._refresh_api_endpoints()
+
+    def _register_ad_group_sync(self):
+        """Ensure AD groups are synced at startup and after migrations."""
+
         try:
             from django.db.models.signals import post_migrate
             from .models import ADGroupAssociation
@@ -29,17 +34,64 @@ class MyviewConfig(AppConfig):
                 except Exception:
                     logger.exception("Post-migrate cached AD group sync failed")
 
-            post_migrate.connect(_post_migrate_sync, sender=self, dispatch_uid="myview_post_migrate_sync")
+            post_migrate.connect(
+                _post_migrate_sync,
+                sender=self,
+                dispatch_uid="myview_post_migrate_sync",
+            )
         except Exception:
             logger.exception("Failed to register AD group sync hooks in AppConfig.ready()")
 
-        # # Ensure server is running in development mode before running the script.
-        # from django.conf import settings
-        # call_command('runscript', 'utils.cronjob_update_endpoints')
-        # # if settings.DEBUG:
-        # #     try:
-                
-        # #         # call_command('runscript', 'utils.create_new_database')
-        # #         pass
-        # #     except:
-        # #         pass  # Handle any expected exceptions or log errors as needed
+    def _register_endpoint_refresh(self):
+        """Register a post-migrate hook to refresh API endpoints automatically."""
+
+        try:
+            from django.db.models.signals import post_migrate
+
+            def _post_migrate_refresh(sender, **kwargs):
+                self._refresh_api_endpoints()
+
+            post_migrate.connect(
+                _post_migrate_refresh,
+                sender=self,
+                dispatch_uid="myview_post_migrate_endpoint_refresh",
+            )
+        except Exception:
+            logger.exception("Failed to register endpoint refresh hook")
+
+    def _refresh_api_endpoints(self):
+        """Populate the Endpoint table from the current OpenAPI schema."""
+
+        try:
+            from utils.cronjob_update_endpoints import updateEndpoints
+        except Exception:
+            logger.exception("Unable to import endpoint updater")
+            return
+
+        from django.apps import apps as django_apps
+        from django.db import connection
+        from django.db.utils import OperationalError, ProgrammingError
+
+        try:
+            Endpoint = django_apps.get_model("myview", "Endpoint")
+        except LookupError:
+            logger.info("Endpoint model not available; skipping endpoint refresh")
+            return
+
+        # Ensure the table exists before attempting to update.
+        try:
+            with connection.cursor():
+                table_names = set(connection.introspection.table_names())
+            if Endpoint._meta.db_table not in table_names:
+                return
+        except (OperationalError, ProgrammingError):
+            logger.info("Skipping endpoint refresh; database not ready")
+            return
+        except Exception:
+            logger.exception("Failed while checking Endpoint table availability")
+            return
+
+        try:
+            updateEndpoints()
+        except Exception:
+            logger.exception("Automatic endpoint refresh failed")


### PR DESCRIPTION
## Summary
- automatically trigger endpoint synchronization during app startup
- register a post-migrate hook so endpoint records stay aligned with the OpenAPI schema
- guard the automatic refresh against missing tables or dependencies to avoid startup failures

## Testing
- `python manage.py check` *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da88b68bdc832c8c07f4d91d747621