### PR TITLE
Ensure limiter types are created automatically

### DIFF
--- a/app-main/myview/apps.py
+++ b/app-main/myview/apps.py
@@ -15,6 +15,7 @@ class MyviewConfig(AppConfig):
         self._register_ad_group_sync()
         self._register_endpoint_refresh()
         self._refresh_api_endpoints()
+        self._register_limiter_type_sync()
 
     def _register_ad_group_sync(self):
         """Ensure AD groups are synced at startup and after migrations."""
@@ -113,3 +114,123 @@ class MyviewConfig(AppConfig):
             updateEndpoints()
         except Exception:
             logger.exception("Automatic endpoint refresh failed")
+
+    def _register_limiter_type_sync(self):
+        """Ensure limiter types exist both at startup and after migrations."""
+
+        try:
+            self._ensure_limiter_types()
+        except Exception:
+            logger.exception("Initial limiter type sync failed")
+
+        try:
+            from django.db.models.signals import post_migrate
+
+            def _post_migrate_sync(sender, **kwargs):
+                try:
+                    self._ensure_limiter_types()
+                except Exception:
+                    logger.exception("Post-migrate limiter type sync failed")
+
+            post_migrate.connect(
+                _post_migrate_sync,
+                sender=self,
+                dispatch_uid="myview_post_migrate_limiter_type_sync",
+            )
+        except Exception:
+            logger.exception("Failed to register limiter type sync hook")
+
+    def _ensure_limiter_types(self):
+        """Create or update limiter type entries for known limiter models."""
+
+        from django.apps import apps as django_apps
+        from django.contrib.contenttypes.models import ContentType
+
+        try:
+            with connection.cursor():
+                table_names = set(connection.introspection.table_names())
+        except (OperationalError, ProgrammingError):
+            logger.info("Skipping limiter type sync; database not ready")
+            return
+        except Exception:
+            logger.exception("Failed while checking limiter type table availability")
+            return
+
+        limiter_table = "myview_limitertype"
+        if limiter_table not in table_names:
+            logger.info("Skipping limiter type sync; %s table missing", limiter_table)
+            return
+
+        if "django_content_type" not in table_names:
+            logger.info("Skipping limiter type sync; content type table missing")
+            return
+
+        try:
+            LimiterType = django_apps.get_model("myview", "LimiterType")
+        except LookupError:
+            logger.info("LimiterType model not available; skipping limiter type sync")
+            return
+
+        limiter_models = [
+            ("myview", "IPLimiter"),
+            ("myview", "ADOrganizationalUnitLimiter"),
+        ]
+
+        for app_label, model_name in limiter_models:
+            try:
+                model = django_apps.get_model(app_label, model_name)
+            except LookupError:
+                logger.warning("Limiter model %s.%s not found", app_label, model_name)
+                continue
+
+            try:
+                content_type = ContentType.objects.get_for_model(model)
+            except Exception:
+                logger.exception("Failed resolving content type for %s.%s", app_label, model_name)
+                continue
+
+            desired_name = str(getattr(model._meta, "verbose_name", model_name))
+            desired_description = (model.__doc__ or "").strip()
+
+            limiter_type = None
+
+            try:
+                limiter_type = LimiterType.objects.get(content_type=content_type)
+            except LimiterType.DoesNotExist:
+                try:
+                    limiter_type = LimiterType.objects.get(name=desired_name)
+                except LimiterType.DoesNotExist:
+                    limiter_type = LimiterType(
+                        name=desired_name,
+                        content_type=content_type,
+                        description=desired_description,
+                    )
+                except LimiterType.MultipleObjectsReturned:
+                    limiter_type = LimiterType.objects.filter(name=desired_name).first()
+            except LimiterType.MultipleObjectsReturned:
+                limiter_type = LimiterType.objects.filter(content_type=content_type).first()
+
+            if limiter_type is None:
+                limiter_type = LimiterType(
+                    name=desired_name,
+                    content_type=content_type,
+                    description=desired_description,
+                )
+
+            updated = False
+
+            if limiter_type.pk is None:
+                updated = True
+            else:
+                if limiter_type.name != desired_name:
+                    limiter_type.name = desired_name
+                    updated = True
+                if limiter_type.content_type_id != content_type.id:
+                    limiter_type.content_type = content_type
+                    updated = True
+                if limiter_type.description != desired_description:
+                    limiter_type.description = desired_description
+                    updated = True
+
+            if updated:
+                limiter_type.save()

--- a/app-main/myview/tests.py
+++ b/app-main/myview/tests.py
@@ -1,6 +1,32 @@
-from django.test import TestCase, Client
-from django.urls import reverse
-from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+
+class LimiterTypeSyncTests(TestCase):
+    """Tests for automatic limiter type population."""
+
+    def test_ensure_limiter_types_populates_expected_entries(self):
+        from django.apps import apps as django_apps
+
+        config = django_apps.get_app_config('myview')
+        LimiterType = django_apps.get_model('myview', 'LimiterType')
+
+        LimiterType.objects.all().delete()
+
+        config._ensure_limiter_types()
+
+        limiters = LimiterType.objects.order_by('name')
+
+        self.assertEqual(limiters.count(), 2)
+
+        ip_limiter = limiters.filter(name='IP Limiter').first()
+        self.assertIsNotNone(ip_limiter)
+        self.assertEqual(ip_limiter.description, 'This model represents a specific IP limiter.')
+        self.assertEqual(ip_limiter.content_type.model, 'iplimiter')
+
+        ou_limiter = limiters.filter(name='AD Organizational Unit Limiter').first()
+        self.assertIsNotNone(ou_limiter)
+        self.assertEqual(ou_limiter.description, 'This model represents an AD organizational unit limiter.')
+        self.assertEqual(ou_limiter.content_type.model, 'adorganizationalunitlimiter')
 
 
 


### PR DESCRIPTION
## Summary
- ensure limiter type entries are automatically created at startup and after migrations
- add coverage to verify limiter type synchronization populates expected entries

## Testing
- python manage.py test myview.tests.LimiterTypeSyncTests

------
https://chatgpt.com/codex/tasks/task_e_68da8db0081c832c9c694ce0a65f66e0