### PR TITLE
Add limiter type filtering control to endpoint table

### DIFF
--- a/app-main/myview/static/myview/js/frontpage.js
+++ b/app-main/myview/static/myview/js/frontpage.js
@@ -9,6 +9,7 @@ class App {
             this.baseUIBinder = baseUIBinder;
             this.appUtils = appUtils;
             this.baseAppUtils = baseAppUtils;
+            this.selectedLimiterTypes = new Set();
             this._setBindings();
             App.instance = this;
         }
@@ -25,28 +26,74 @@ class App {
         //     this.handleCreateNewApiTokenBtn(event, this);
         // });
 
-        const generateTokenBtn = `#${this.uiBinder.generateTokenBtn[0].id}`; // this is the button that will trigger the modal
-        const modalId = 'tokenDisplayModal';
-        const modalConfirmBtn = 'modalConfirmBtn'; // these are refering to elements generation innside the modal, not the main page
-        this.baseAppUtils.setModal(generateTokenBtn, modalId, {
-            title: 'Generate New Token',
-            body: '<p>The token will only be displayed once, are you sure you want to generate a new token?</p>',
-            footer: `
-                <button type="button" class="btn btn-danger" id="${modalConfirmBtn}">Generate New Token <span id="loadingSpinnerGenerateTokenBtn" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none;"></span></button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No, Cancel</button>
-            `,
-            eventListeners: [
-                {
-                    selector: '#modalConfirmBtn',
-                    event: 'click',
-                    handler: (event) => {
-                        // how do i access modalId in this scope?
-                        this.handleCreateNewApiToken(event, modalId, this);
+        if (this.uiBinder.generateTokenBtn.length) {
+            const generateTokenBtn = `#${this.uiBinder.generateTokenBtn[0].id}`; // this is the button that will trigger the modal
+            const modalId = 'tokenDisplayModal';
+            const modalConfirmBtn = 'modalConfirmBtn'; // these are refering to elements generation innside the modal, not the main page
+            this.baseAppUtils.setModal(generateTokenBtn, modalId, {
+                title: 'Generate New Token',
+                body: '<p>The token will only be displayed once, are you sure you want to generate a new token?</p>',
+                footer: `
+                    <button type="button" class="btn btn-danger" id="${modalConfirmBtn}">Generate New Token <span id="loadingSpinnerGenerateTokenBtn" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none;"></span></button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No, Cancel</button>
+                `,
+                eventListeners: [
+                    {
+                        selector: '#modalConfirmBtn',
+                        event: 'click',
+                        handler: (event) => {
+                            // how do i access modalId in this scope?
+                            this.handleCreateNewApiToken(event, modalId, this);
+                        }
                     }
-                }
-            ]
-        });
+                ]
+            });
+        }
 
+        if (this.uiBinder.filterLimiterTypeBtn.length) {
+            const filterLimiterBtnSelector = `#${this.uiBinder.filterLimiterTypeBtn[0].id}`;
+            const limiterModalId = 'limiterTypeFilterModal';
+            const availableLimiterTypes = this.appUtils.getAvailableLimiterTypes();
+
+            const modalBody = this.appUtils.generateLimiterTypeOptionsHtml(availableLimiterTypes);
+            const modalFooter = `
+                <button type="button" class="btn btn-primary" id="applyLimiterFilterBtn">Apply filter</button>
+                <button type="button" class="btn btn-outline-secondary" id="clearLimiterFilterBtn">Clear filter</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            `;
+
+            this.baseAppUtils.setModal(filterLimiterBtnSelector, limiterModalId, {
+                title: 'Filter endpoints by limiter type',
+                body: modalBody,
+                footer: modalFooter,
+                eventListeners: [
+                    {
+                        selector: '#applyLimiterFilterBtn',
+                        event: 'click',
+                        handler: (event) => {
+                            this.handleApplyLimiterFilter(event, limiterModalId);
+                        }
+                    },
+                    {
+                        selector: '#clearLimiterFilterBtn',
+                        event: 'click',
+                        handler: (event) => {
+                            this.handleClearLimiterFilter(event, limiterModalId);
+                        }
+                    }
+                ]
+            });
+
+            const limiterModalElement = document.getElementById(limiterModalId);
+            if (limiterModalElement) {
+                limiterModalElement.addEventListener('show.bs.modal', () => {
+                    this.populateLimiterModalSelections(limiterModalId);
+                });
+            }
+        }
+
+        this.updateLimiterFilterSummary();
+        this.filterEndpointTable();
     }
 
 
@@ -113,6 +160,78 @@ class App {
 
 
     }
+
+    handleApplyLimiterFilter(event, modalId) {
+        event.preventDefault();
+        const selectedCheckboxes = Array.from(document.querySelectorAll(`#${modalId} input[type="checkbox"]:checked`));
+        const selectedValues = selectedCheckboxes.map((checkbox) => checkbox.value);
+
+        this.selectedLimiterTypes = new Set(selectedValues);
+        this.filterEndpointTable();
+        this.updateLimiterFilterSummary();
+
+        const modalElement = document.getElementById(modalId);
+        if (modalElement) {
+            const modalInstance = bootstrap.Modal.getInstance(modalElement);
+            if (modalInstance) {
+                modalInstance.hide();
+            }
+        }
+    }
+
+    handleClearLimiterFilter(event, modalId) {
+        event.preventDefault();
+        this.selectedLimiterTypes.clear();
+        this.filterEndpointTable();
+        this.updateLimiterFilterSummary();
+        this.populateLimiterModalSelections(modalId);
+    }
+
+    filterEndpointTable() {
+        const rows = document.querySelectorAll('[data-endpoint-row]');
+        const hasActiveFilters = this.selectedLimiterTypes && this.selectedLimiterTypes.size > 0;
+
+        rows.forEach((row) => {
+            const limiterType = (row.getAttribute('data-limiter-type') || 'None').trim() || 'None';
+            if (!hasActiveFilters || this.selectedLimiterTypes.has(limiterType)) {
+                row.classList.remove('d-none');
+            } else {
+                row.classList.add('d-none');
+            }
+        });
+    }
+
+    populateLimiterModalSelections(modalId) {
+        const modalElement = document.getElementById(modalId);
+        if (!modalElement) {
+            return;
+        }
+
+        const checkboxes = modalElement.querySelectorAll('input[type="checkbox"]');
+        checkboxes.forEach((checkbox) => {
+            if (!this.selectedLimiterTypes || this.selectedLimiterTypes.size === 0) {
+                checkbox.checked = false;
+            } else {
+                checkbox.checked = this.selectedLimiterTypes.has(checkbox.value);
+            }
+        });
+    }
+
+    updateLimiterFilterSummary() {
+        if (!this.uiBinder.limiterFilterSummary || this.uiBinder.limiterFilterSummary.length === 0) {
+            return;
+        }
+
+        if (!this.selectedLimiterTypes || this.selectedLimiterTypes.size === 0) {
+            this.uiBinder.limiterFilterSummary.text('');
+            this.uiBinder.limiterFilterSummary.addClass('d-none');
+            return;
+        }
+
+        const summaryText = Array.from(this.selectedLimiterTypes).join(', ');
+        this.uiBinder.limiterFilterSummary.text(summaryText);
+        this.uiBinder.limiterFilterSummary.removeClass('d-none');
+    }
     static getInstance(uiBinder = UIBinder.getInstance(), baseUIBinder = BaseUIBinder.getInstance(), appUtils = AppUtils.getInstance(), baseAppUtils = BaseAppUtils.getInstance()) {
         if (!App.instance) {
             App.instance = new App(uiBinder, baseUIBinder, appUtils, baseAppUtils);
@@ -137,10 +256,60 @@ class AppUtils {
     }
 
 
+    getAvailableLimiterTypes() {
+        if (this.availableLimiterTypes) {
+            return this.availableLimiterTypes;
+        }
 
-        
+        const scriptElement = document.getElementById('available-limiter-types-data');
+        if (!scriptElement) {
+            this.availableLimiterTypes = [];
+            return this.availableLimiterTypes;
+        }
 
+        try {
+            const parsedData = JSON.parse(scriptElement.textContent);
+            this.availableLimiterTypes = Array.isArray(parsedData) ? parsedData : [];
+        } catch (error) {
+            console.error('Failed to parse available limiter types:', error);
+            this.availableLimiterTypes = [];
+        }
 
+        return this.availableLimiterTypes;
+    }
+
+    escapeHtml(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    generateLimiterTypeOptionsHtml(limiterTypes = []) {
+        if (!Array.isArray(limiterTypes) || limiterTypes.length === 0) {
+            return '<p class="mb-0">No limiter types available.</p>';
+        }
+
+        const optionsHtml = limiterTypes.map((type, index) => {
+            const safeValue = typeof type === 'string' ? type.trim() : '';
+            const escapedLabel = this.escapeHtml(safeValue || 'None');
+            const checkboxId = `limiterTypeOption-${index}`;
+            return `
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" value="${escapedLabel}" id="${checkboxId}">
+                    <label class="form-check-label" for="${checkboxId}">${escapedLabel}</label>
+                </div>
+            `;
+        }).join('');
+
+        return `<fieldset><legend class="visually-hidden">Limiter type filters</legend>${optionsHtml}</fieldset>`;
+    }
 
 
     static getInstance() {
@@ -158,6 +327,8 @@ class UIBinder {
     constructor() {
         if (!UIBinder.instance) {
             this.generateTokenBtn = $('#generateTokenBtn');
+            this.filterLimiterTypeBtn = $('#filterLimiterTypeBtn');
+            this.limiterFilterSummary = $('#limiterFilterSummary');
             UIBinder.instance = this;
         }
         return UIBinder.instance;

--- a/app-main/myview/templates/myview/frontpage.html
+++ b/app-main/myview/templates/myview/frontpage.html
@@ -2,7 +2,7 @@
 
 <!-- i18n and static are Django template tags. They are used to load the i18n and static template tags. The i18n template tag is used to mark strings for translation. -->
 <!-- The static is a template tag that is used to load the static template tag library. This library provides a way to reference static files, such as CSS, JavaScript, or image files, which are not tied to a particular instance of a model in your Django app. -->
-{% load i18n static %}
+{% load i18n static json_script %}
 
 
 {# title #}
@@ -29,7 +29,15 @@
     </div>
 
     <div class="container my-4">
-        <h2>My Accessible Endpoints</h2>
+        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mb-3">
+            <h2 class="mb-0">My Accessible Endpoints</h2>
+            <div class="d-flex align-items-center gap-2">
+                <span id="limiterFilterSummary" class="badge bg-info text-dark d-none"></span>
+                <button id="filterLimiterTypeBtn" class="btn btn-outline-primary btn-sm">
+                    Filter limiter types
+                </button>
+            </div>
+        </div>
         <div class="table-responsive">
             <table class="table table-striped">
                 <thead>
@@ -43,7 +51,7 @@
                 </thead>
                 <tbody>
                     {% for endpoint in user_endpoints %}
-                    <tr>
+                    <tr data-endpoint-row data-limiter-type="{{ endpoint.limiter_type }}">
                         <th scope="row">{{ forloop.counter }}</th>
                         <td>{{ endpoint.method }} {{ endpoint.path }}</td>
                         <!-- <td> not working rigth now -->
@@ -92,6 +100,7 @@
     </div>
 
 </div>
+{% json_script available_limiter_types "available-limiter-types-data" %}
     <script src="{% static 'myview/js/frontpage.js' %}" defer></script>
     <link rel="stylesheet" type="text/css" media="all" href="{% static 'myview/css/frontpage.css' %}" />
 {% endblock %}

--- a/app-main/myview/views.py
+++ b/app-main/myview/views.py
@@ -71,13 +71,17 @@ class BaseView(View):
 
         # Filter endpoints to include only user-specific group access information
         filtered_endpoints = []
+        available_limiter_types = set()
         for endpoint in user_endpoints:
             filtered_groups = endpoint.ad_groups.filter(members=self.request.user)
+            limiter_label = endpoint.limiter_type.name if endpoint.limiter_type else "None"
+            available_limiter_types.add(limiter_label)
             filtered_endpoints.append({
+                'id': endpoint.id,
                 'method': endpoint.method,
                 'path': endpoint.path,
                 'ad_groups': filtered_groups,
-                'limiter_type': endpoint.limiter_type.name if endpoint.limiter_type else "None",
+                'limiter_type': limiter_label,
                 'no_limit': endpoint.no_limit
             })
 
@@ -116,6 +120,7 @@ class BaseView(View):
             'user_has_mfa_reset_access': self.user_has_mfa_reset_access(),
             'debug': settings.DEBUG,
             'all_limiter_types': associated_limiter_types,
+            'available_limiter_types': sorted(available_limiter_types),
         }
 
         return context


### PR DESCRIPTION
## Summary
- add a limiter type filter action and modal to the accessible endpoints table
- expose endpoint limiter metadata to the template so the client script can filter rows client-side
- enhance the front-page script with stateful filtering helpers and UI bindings

## Testing
- python app-main/manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68da8dcc23b8832c837b5e1d3d1d3b18