### PR TITLE
Add missing runtime dependencies for production startup

### DIFF
--- a/app-main/requirements.txt
+++ b/app-main/requirements.txt
@@ -17,6 +17,7 @@ django-cas-ng==4.3.0
 django-extensions==3.2.3
 djangorestframework==3.15.2
 drf-yasg==1.21.7
+gunicorn==21.2.0
 et-xmlfile==1.1.0
 exceptiongroup==1.2.0
 frozenlist==1.4.1
@@ -37,6 +38,7 @@ microsoft-kiota-http==1.3.1
 msal==1.27.0
 msal-extensions==1.1.0
 msgraph-core==1.0.0
+psycopg2-binary==2.9.9
 multidict==6.0.5
 mysqlclient==2.2.4
 numpy==2.1.2


### PR DESCRIPTION
## Summary
- add gunicorn to the Python dependencies so the container entrypoint can start
- include psycopg2-binary to satisfy PostgreSQL connections when environment variables are set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de807dc840832cae790077afe8ef67