### PR TITLE
Handle missing ServiceToken table when fetching bearer tokens

### DIFF
--- a/app-main/graph/scripts/_graph_get_bearertoken.py
+++ b/app-main/graph/scripts/_graph_get_bearertoken.py
@@ -1,12 +1,33 @@
+import logging
 import os
 from datetime import timedelta
 
 import requests
-from django.db import transaction
+from django.db import OperationalError, ProgrammingError, transaction
 from django.utils import timezone
 from dotenv import load_dotenv
 
 from ..models import ServiceToken
+
+
+logger = logging.getLogger(__name__)
+
+
+class _EphemeralServiceToken:
+    """Fallback token object used when the ServiceToken table is unavailable."""
+
+    def __init__(self, *, service: str):
+        self.service = service
+        self.pk = None
+        self.access_token = ""
+        self.expires_at = timezone.now() - timedelta(seconds=1)
+
+    def is_expired(self, *, buffer_seconds: int = 0) -> bool:  # pragma: no cover - simple proxy
+        buffer = timedelta(seconds=max(buffer_seconds, 0))
+        return self.expires_at <= timezone.now() + buffer
+
+    def save(self, *args, **kwargs):  # pragma: no cover - no-op persistence proxy
+        return None
 
 
 TOKEN_REFRESH_BUFFER_SECONDS = int(os.getenv("GRAPH_ACCESS_BEARER_TOKEN_REFRESH_BUFFER", "120") or 120)
@@ -58,15 +79,23 @@ def _generate_new_token():
 def _get_token_record():
     """Fetch the persisted Graph token row with a database lock."""
 
-    with transaction.atomic():
-        token_obj, _created = ServiceToken.objects.select_for_update().get_or_create(
-            service=ServiceToken.Service.GRAPH,
-            defaults={
-                "access_token": "",
-                "expires_at": timezone.now() - timedelta(seconds=1),
-            },
+    try:
+        with transaction.atomic():
+            token_obj, _created = ServiceToken.objects.select_for_update().get_or_create(
+                service=ServiceToken.Service.GRAPH,
+                defaults={
+                    "access_token": "",
+                    "expires_at": timezone.now() - timedelta(seconds=1),
+                },
+            )
+            return token_obj
+    except (OperationalError, ProgrammingError) as exc:
+        logger.warning(
+            "ServiceToken table unavailable while fetching Graph token; "
+            "operating without persistence. Error: %s",
+            exc,
         )
-        return token_obj
+        return _EphemeralServiceToken(service=ServiceToken.Service.GRAPH)
 
 
 def _refresh_token(token_obj):
@@ -78,7 +107,16 @@ def _refresh_token(token_obj):
 
     token_obj.access_token = new_token
     token_obj.expires_at = timezone.now() + timedelta(seconds=DEFAULT_TOKEN_TTL_SECONDS)
-    token_obj.save(update_fields=["access_token", "expires_at", "updated_at"])
+
+    if getattr(token_obj, "pk", None) is not None:
+        try:
+            token_obj.save(update_fields=["access_token", "expires_at", "updated_at"])
+        except (OperationalError, ProgrammingError) as exc:
+            logger.warning(
+                "Unable to persist refreshed Graph token; operating in-memory. Error: %s",
+                exc,
+            )
+
     return token_obj.access_token
 
 
@@ -105,3 +143,4 @@ def run():
 
 if __name__ == "__main__":
     run()
+


### PR DESCRIPTION
## Summary
- add transient ServiceToken fallbacks so Graph and Defender token fetchers continue working before migrations run
- log warnings and skip persistence when the ServiceToken table cannot be updated

## Testing
- cd app-main && python -m compileall graph/scripts/_graph_get_bearertoken.py
- cd app-main && python -m compileall defender/scripts/_defender_get_bearertoken.py

------
https://chatgpt.com/codex/tasks/task_e_68de8b3afbdc832cbad4064100de9991