### PR TITLE
Fix static and media volume permissions for Coolify deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN groupadd --system django \
     && mkdir -p /home/django \
     && chown -R django:django /home/django /app
 
-USER django
+USER root
 
 ENV PATH="/home/django/.local/bin:${PATH}" \
     PYTHONPATH=/app \


### PR DESCRIPTION
## Summary
- switch the container back to running the entrypoint as root so it can prepare mounted storage
- update the entrypoint to create and chown static/media directories before running Django tasks
- ensure manage commands and the application itself still run as the django user after dropping privileges

## Testing
- not run (deployment configuration changes only)

------
https://chatgpt.com/codex/tasks/task_e_68df87c9fd54832c9bb0aed746c8879c