### PR TITLE
Document default Postgres password alignment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,11 @@ DEVCONTAINER_GITHUB_NAME="Your Name"
 DEVCONTAINER_GITHUB_EMAIL=you@example.com
 
 # ----- docker-compose environment variables -- starts here ----- #
+# Use the same credentials for both the web and database services.
+# Change these values in production and update the database password accordingly.
 POSTGRES_DB=api_security_dtu_dk
 POSTGRES_USER=api_security_dtu_dk_user
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=please-change-me
 POSTGRES_HOST=xx-api-security-ait-dtu-dk-postgres-service
 # ----- docker-compose environment variables -- ends here ----- #
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Environment keys surfaced in Coolify by default (no secrets committed):
 - `DJANGO_SECURE_SSL_REDIRECT` (default: `true`)
 - `POSTGRES_DB` (default: `app`)
 - `POSTGRES_USER` (default: `app`)
+- `POSTGRES_PASSWORD` (default: `please-change-me`; update both the app and database if you change it)
 
 Required at deploy time (Coolify will prompt):
 
@@ -86,6 +87,8 @@ To run the same stack locally without Coolify:
 
 ```bash
 cp .env.example .env
+# Update POSTGRES_PASSWORD if you do not want to use the default `please-change-me`
+# and ensure the value matches the password stored in the PostgreSQL volume.
 # Create the external Traefik network expected by the compose file (run once)
 docker network create coolify-network
 docker compose -f docker-compose.coolify.yml up --build

--- a/docs/coolify-deployment-guide.md
+++ b/docs/coolify-deployment-guide.md
@@ -26,7 +26,7 @@ At minimum set the following values:
 | `DJANGO_CSRF_COOKIE_DOMAIN` | Cookie domain; often same as `SERVICE_FQDN_WEB`. |
 | `DJANGO_SESSION_COOKIE_SECURE`, `DJANGO_CSRF_COOKIE_SECURE`, `DJANGO_SECURE_SSL_REDIRECT` | Production security flags (defaults true). |
 | `DJANGO_SECRET` | A long random string used for Django's cryptographic signing. (required) |
-| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Credentials for PostgreSQL. (required: `POSTGRES_PASSWORD`) |
+| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Credentials for PostgreSQL. (required: `POSTGRES_PASSWORD`). The default password in `.env.example` is `please-change-me`; keep the same value for both the web and database services. |
 | `TRAEFIK_HOST` | FQDN that Traefik should route to this application. |
 | `TRAEFIK_NETWORK`, `TRAEFIK_ENTRYPOINT`, `TRAEFIK_CERTRESOLVER` | Networking metadata; defaults match a standard Coolify install. Override if your Traefik setup differs. |
 | `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_PASSWORD` | Credentials you will use to create an administrative user after deployment. |
@@ -104,3 +104,11 @@ docker network create coolify-network
 
 If your Traefik installation uses a different network name, set the `TRAEFIK_NETWORK` environment variable in Coolify to that
 name instead of creating `coolify-network`.
+
+### `django.db.utils.OperationalError: password authentication failed`
+
+This indicates Django cannot authenticate to PostgreSQL. Confirm that:
+
+1. The value of `POSTGRES_PASSWORD` is identical for the `web` and `db` services.
+2. The password matches the credentials already stored in the PostgreSQL data volume. If you change the password, update the database user inside PostgreSQL or recreate the volume so the new credentials take effect.
+3. Environment variables are not defined as empty strings in Coolify or your `.env` file. Remove unused keys rather than leaving them blank so Docker Compose can fall back to the defaults documented in `.env.example`.


### PR DESCRIPTION
## Summary
- set a non-empty default `POSTGRES_PASSWORD` in `.env.example` so the app and database share the same credentials during local and Coolify deployments
- document the default password in the README and remind operators to keep the application and database values in sync
- expand the Coolify deployment guide with guidance and troubleshooting steps for PostgreSQL password mismatches

## Testing
- not run (documentation-only updates)


------
https://chatgpt.com/codex/tasks/task_e_68df9001cd28832cb897eccb00aefa68