### PR TITLE
Fix Coolify Traefik routing for API host

### DIFF
--- a/docker-compose.coolify.yaml
+++ b/docker-compose.coolify.yaml
@@ -38,7 +38,7 @@ services:
       - traefik
     labels:
       - traefik.enable=true
-      - traefik.http.routers.api_security.rule=Host(`${TRAEFIK_HOST:-api.example.com}`)
+      - traefik.http.routers.api_security.rule=Host(`${SERVICE_FQDN_WEB:-api.security.ait.dtu.dk}`)
       - traefik.http.routers.api_security.entrypoints=${TRAEFIK_ENTRYPOINT:-websecure}
       - traefik.http.routers.api_security.tls=true
       - traefik.http.routers.api_security.tls.certresolver=${TRAEFIK_CERTRESOLVER:-letsencrypt}
@@ -72,4 +72,4 @@ networks:
     driver: bridge
   traefik:
     name: ${TRAEFIK_NETWORK:-coolify-network}
-    driver: bridge
+    external: true


### PR DESCRIPTION
## Summary
- point the Traefik host rule to the deployed API domain
- mark the Traefik network as external so Coolify's proxy can attach

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df93b04b50832c83152dcc04fb17be