### PR TITLE
Configure WhiteNoise static file serving

### DIFF
--- a/app-main/app/settings.py
+++ b/app-main/app/settings.py
@@ -251,6 +251,7 @@ MIGRATION_MODULES = {
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -367,7 +368,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
 STATIC_ROOT = _ensure_storage_dir(
     'DJANGO_STATIC_ROOT',
     default_path=Path('/mnt/shared-project-data/django/staticfiles'),
@@ -377,6 +378,8 @@ STATIC_ROOT = _ensure_storage_dir(
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = _ensure_storage_dir(

--- a/app-main/requirements.txt
+++ b/app-main/requirements.txt
@@ -18,6 +18,7 @@ django-extensions==3.2.3
 djangorestframework==3.15.2
 drf-yasg==1.21.7
 gunicorn==21.2.0
+whitenoise==6.6.0
 et-xmlfile==1.1.0
 exceptiongroup==1.2.0
 frozenlist==1.4.1


### PR DESCRIPTION
## Summary
- add WhiteNoise middleware and storage so Gunicorn can serve collected assets from `STATIC_ROOT`
- normalize the `STATIC_URL` setting for consistent URLs
- declare the `whitenoise` dependency for production images

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e04bf3c8cc832c9e8671689d8b34fb