### PR TITLE
Mirror Coolify FQDN env vars for Traefik

### DIFF
--- a/docker-compose.coolify.yaml
+++ b/docker-compose.coolify.yaml
@@ -10,6 +10,8 @@ services:
     environment:
       SERVICE_FQDN_WEB: ${SERVICE_FQDN_WEB:-api.security.ait.dtu.dk}
       SERVICE_URL_WEB: ${SERVICE_URL_WEB:-https://api.security.ait.dtu.dk}
+      service_fqdn_web: ${SERVICE_FQDN_WEB:-api.security.ait.dtu.dk}
+      service_url_web: ${SERVICE_URL_WEB:-https://api.security.ait.dtu.dk}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-api.security.ait.dtu.dk,localhost,127.0.0.1}
       DJANGO_CSRF_TRUSTED_ORIGINS: ${DJANGO_CSRF_TRUSTED_ORIGINS:-https://api.security.ait.dtu.dk}
       DJANGO_CSRF_COOKIE_DOMAIN: ${DJANGO_CSRF_COOKIE_DOMAIN:-}

--- a/docs/coolify-deployment-guide.md
+++ b/docs/coolify-deployment-guide.md
@@ -114,6 +114,23 @@ This indicates Django cannot authenticate to PostgreSQL. Confirm that:
 
 ### Requests time out at the gateway
 
+### Traefik log: `invalid value for HostSNI matcher`
+
+If the Coolify proxy logs show entries similar to:
+
+```
+Error while adding rule HostSNI(`${service_fqdn_web:-api.security.ait.dtu.dk}`): invalid value for HostSNI matcher
+```
+
+it means Traefik never received a fully expanded hostname for the router. Coolify
+injects both upper- and lower-case variants of the `SERVICE_FQDN_WEB` environment
+variable into the Docker labels, so leaving the value empty results in a literal
+`${service_fqdn_web:-...}` string reaching Traefik. Define `SERVICE_FQDN_WEB` (and
+optionally `SERVICE_URL_WEB`) in Coolify's **Environment Variables** tab or your
+`.env` file before deploying so the compose file can propagate the hostname to both
+case variants. After saving the variables, redeploy the stack; the router will be
+created with the concrete hostname and the error disappears.
+
 Traefik will return a 504 timeout if it cannot reach Gunicorn inside the Django container. To confirm whether requests actually
 arrive at the application, tail the **Server → web** logs in Coolify while making a request to your domain. Each request now
 emits a Gunicorn access log entry such as:


### PR DESCRIPTION
## Summary
- expose lowercase service_fqdn_web/service_url_web env vars in the Coolify compose stack so Traefik receives a concrete hostname
- document the HostSNI matcher error in the Coolify deployment troubleshooting guide with remediation steps

## Testing
- not run (documentation and compose changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e04e93b250832cbe34d212e8e2e973