### PR TITLE
Defer endpoint refresh database access until post-migrate

### DIFF
--- a/app-main/utils/cronjob_update_endpoints.py
+++ b/app-main/utils/cronjob_update_endpoints.py
@@ -1,9 +1,24 @@
-from drf_yasg.generators import OpenAPISchemaGenerator
-from drf_yasg import openapi
-from django.urls import get_resolver
-from myview.models import Endpoint  # Update 'myview' with the actual name of your app
+import logging
 
-def updateEndpoints():
+from django.apps import apps as django_apps
+from django.db import DEFAULT_DB_ALIAS
+from django.urls import get_resolver
+from drf_yasg import openapi
+from drf_yasg.generators import OpenAPISchemaGenerator
+
+
+def updateEndpoints(*, using=None, logger: logging.Logger | None = None):
+    log = logger or logging.getLogger(__name__)
+    if using is None:
+        using = DEFAULT_DB_ALIAS
+
+    Endpoint = django_apps.get_model("myview", "Endpoint")
+    if Endpoint is None:
+        log.info("Endpoint model unavailable; skipping endpoint synchronisation")
+        return
+
+    manager = Endpoint.objects.db_manager(using)
+
     # Instantiate the schema generator
     generator = OpenAPISchemaGenerator(
         info=openapi.Info(
@@ -21,7 +36,7 @@ def updateEndpoints():
     schema = generator.get_schema(request=None, public=True)
 
     # Create a set of all endpoint paths in the Django model
-    existing_endpoints = set(Endpoint.objects.values_list('path', flat=True))
+    existing_endpoints = set(manager.values_list('path', flat=True))
 
     # Ensure the special 'any' path and method exists
     # Endpoint.objects.get_or_create(path='any', method='any')
@@ -34,21 +49,22 @@ def updateEndpoints():
             method = method.lower()
             method = path_data.operations[0][0] if path_data.operations[0][0] in common_http_methods else None
             # Check if the endpoint (with method) already exists
-            endpoint, created = Endpoint.objects.get_or_create(
+            endpoint, created = manager.get_or_create(
                 path=path,
                 method=method,
                 defaults={'path': path, 'method': method}
             )
             if created:
-                print(f"Added new endpoint: {method} {path}")
+                log.info("Added new endpoint: %s %s", method, path)
             else:
                 # Remove the endpoint from the set of existing endpoints if it still exists in the schema
                 existing_endpoints.discard(path)
 
     # Delete any endpoints that were not found in the schema
-    Endpoint.objects.filter(path__in=existing_endpoints).delete()
+    if existing_endpoints:
+        manager.filter(path__in=existing_endpoints).delete()
 
-    print("Completed updating endpoints.")
+    log.info("Completed updating endpoints.")
 
 
 def run():


### PR DESCRIPTION
## Summary
- defer automatic endpoint refresh until migrations finish committing and the app registry is ready
- harden database readiness checks for AD group and OU sync hooks to respect the active database alias
- teach the endpoint refresh utility to lazily resolve the Endpoint model, support custom database aliases, and emit structured logging

## Testing
- python manage.py check
- python manage.py migrate

------
https://chatgpt.com/codex/tasks/task_e_68e1060178a4832c804c7c380806345e