### PR TITLE
Preserve environment when delegating commands to runuser

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 run_as_app_user() {
   if [ "$(id -u)" = "0" ]; then
     if command -v runuser >/dev/null 2>&1; then
-      runuser -u "$APP_USER" -- "$@"
+      runuser --preserve-environment -u "$APP_USER" -- "$@"
     else
       su -m "$APP_USER" -c "$*"
     fi
@@ -94,7 +94,7 @@ fi
 
 if [ "$(id -u)" = "0" ]; then
   if command -v runuser >/dev/null 2>&1; then
-    exec runuser -u "$APP_USER" -- "$@"
+    exec runuser --preserve-environment -u "$APP_USER" -- "$@"
   else
     exec su -m "$APP_USER" -c "$*"
   fi


### PR DESCRIPTION
## Summary
- preserve the calling environment when invoking runuser so PATH and related variables are kept
- ensures gunicorn and other commands remain discoverable when executed as the application user

## Testing
- APP_USER=root APP_GROUP=root APP_DIR=/workspace/api.security.ait.dtu.dk/app-main DJANGO_MIGRATE=false DJANGO_COLLECTSTATIC=false ./docker/entrypoint.sh python --version

------
https://chatgpt.com/codex/tasks/task_e_68e147f88494832c86b8f226b683cbf4