### PR TITLE
Defer startup sync work and add gunicorn fallback

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -92,6 +92,11 @@ if [ -n "${DJANGO_ADMIN_USERNAME}" ] && [ -n "${DJANGO_ADMIN_PASSWORD}" ]; then
   run_as_app_user python manage.py ensure_admin_user || true
 fi
 
+if [ "$1" = "gunicorn" ] && ! command -v gunicorn >/dev/null 2>&1; then
+  echo "gunicorn command not found; falling back to python -m gunicorn" >&2
+  set -- python -m gunicorn "${@:2}"
+fi
+
 if [ "$(id -u)" = "0" ]; then
   if command -v runuser >/dev/null 2>&1; then
     exec runuser --preserve-environment -u "$APP_USER" -- "$@"


### PR DESCRIPTION
## Summary
- rework the myview AppConfig startup bookkeeping to queue post-migrate aliases and process them lazily on the first request
- guard the docker entrypoint so deployments fall back to `python -m gunicorn` when the gunicorn executable is missing

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e1645a8e80832c9026130276d7f388