### PR TITLE
Default local secrets for docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,67 @@
+version: "3.9"
+
+services:
+  web:
+    container_name: api-security-web-local
+    image: dtuait/api-security-ait-dtu-dk-app-main:python-3.12-bookworm-django-5.1.1-postgres-16-04-10-2025
+    restart: unless-stopped
+    working_dir: /app/app-main
+    # Use the image's default entrypoint so database migrations and collectstatic run automatically.
+    command: gunicorn app.wsgi:application --bind 0.0.0.0:8121
+    ports:
+      - "8121:8121"
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8121/healthz/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    environment:
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1}
+      DJANGO_CSRF_TRUSTED_ORIGINS: ${DJANGO_CSRF_TRUSTED_ORIGINS:-http://localhost:8121,http://127.0.0.1:8121}
+      DJANGO_DEBUG: ${DJANGO_DEBUG:-true}
+      DJANGO_STATIC_ROOT: /data/static
+      DJANGO_MEDIA_ROOT: /data/media
+      DJANGO_SESSION_COOKIE_SECURE: ${DJANGO_SESSION_COOKIE_SECURE:-false}
+      DJANGO_CSRF_COOKIE_SECURE: ${DJANGO_CSRF_COOKIE_SECURE:-false}
+      DJANGO_SECURE_SSL_REDIRECT: ${DJANGO_SECURE_SSL_REDIRECT:-false}
+      DJANGO_SECRET: ${DJANGO_SECRET:-django-insecure-local-dev-secret}
+      POSTGRES_DB: ${POSTGRES_DB:-app}
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-please-change-me}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+    volumes:
+      - static_data:/data/static
+      - media_data:/data/media
+    networks:
+      - internal
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-app}
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-please-change-me}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-app} -d ${POSTGRES_DB:-app}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  static_data:
+  media_data:
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary
- allow the standalone docker-compose stack to start without manually providing secrets by falling back to development defaults
- keep the gunicorn command while documenting that the image entrypoint still runs migrations and collectstatic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e365679214832c8a7f47339e334277