### PR TITLE
Add user profile details to MFA reset lookup

### DIFF
--- a/app-main/graph/scripts/graph_apicall_getuserphoto.py
+++ b/app-main/graph/scripts/graph_apicall_getuserphoto.py
@@ -1,0 +1,55 @@
+"""Fetch a user's profile photo from Microsoft Graph."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Tuple
+
+import requests
+
+from ._graph_get_bearertoken import _get_bearertoken
+from ._http import graph_request
+
+logger = logging.getLogger(__name__)
+
+
+def _error_response(message: str, *, status: int = 503, code: str = "RequestError") -> Tuple[Dict[str, Dict[str, str]], int, str | None]:
+    return {"error": {"code": code, "message": message}}, status, None
+
+
+def get_user_photo(user_principal_name: str) -> Tuple[bytes | Dict[str, object], int, str | None]:
+    """Return the raw profile photo for ``user_principal_name``.
+
+    The response mirrors the :mod:`graph.services` convention by returning a
+    payload plus HTTP status code. On success the payload is raw image bytes.
+    For errors the payload contains the parsed JSON response, falling back to a
+    minimal structure when the service returns non-JSON data.
+    """
+
+    token = _get_bearertoken()
+    if not token:
+        return _error_response("Failed to acquire access token", code="AuthTokenUnavailable")
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "image/*",
+    }
+
+    url = f"https://graph.microsoft.com/v1.0/users/{user_principal_name}/photo/$value"
+
+    try:
+        response = graph_request("GET", url, headers=headers, timeout=20)
+    except requests.exceptions.RequestException as exc:  # pragma: no cover - network failure
+        logger.warning("Microsoft Graph photo request for %s failed: %s", user_principal_name, exc)
+        return _error_response(str(exc))
+
+    content_type = response.headers.get("Content-Type")
+    if response.status_code == 200 and content_type and content_type.startswith("image/"):
+        return response.content, response.status_code, content_type
+
+    try:
+        data = response.json()
+    except ValueError:  # pragma: no cover - defensive
+        data = {"raw": response.text}
+
+    return data, response.status_code, content_type

--- a/app-main/graph/scripts/graph_apicall_listusergroups.py
+++ b/app-main/graph/scripts/graph_apicall_listusergroups.py
@@ -1,0 +1,77 @@
+"""Utilities for listing a user's group memberships via Microsoft Graph."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, Tuple
+
+import requests
+
+from ._graph_get_bearertoken import _get_bearertoken
+from ._http import graph_request
+
+logger = logging.getLogger(__name__)
+
+_GROUP_SELECT = "$select=displayName,mail,id,onPremisesSamAccountName,onPremisesDistinguishedName,@odata.type"
+
+
+def _error_response(message: str, *, status: int = 503, code: str = "RequestError") -> Tuple[Dict[str, Dict[str, str]], int]:
+    return {"error": {"code": code, "message": message}}, status
+
+
+def _iter_member_of(url: str, headers: Dict[str, str]) -> Iterable[Tuple[Dict[str, object], int]]:
+    """Yield memberOf responses following pagination links."""
+
+    next_url: str | None = url
+    while next_url:
+        try:
+            response = graph_request("GET", next_url, headers=headers, timeout=20)
+        except requests.exceptions.RequestException as exc:  # pragma: no cover - network failure
+            logger.warning("Microsoft Graph memberOf request failed: %s", exc)
+            yield _error_response(str(exc))
+            return
+
+        try:
+            data = response.json()
+        except ValueError:  # pragma: no cover - defensive
+            logger.warning(
+                "Received non-JSON response from Microsoft Graph memberOf (status %s)",
+                response.status_code,
+            )
+            data = {"raw": response.text}
+
+        yield data, response.status_code
+
+        next_url = data.get("@odata.nextLink") if isinstance(data, dict) else None
+
+
+
+def list_user_groups(user_principal_name: str) -> Tuple[Dict[str, object], int]:
+    """Return the groups a user belongs to via the Graph ``memberOf`` endpoint."""
+
+    token = _get_bearertoken()
+    if not token:
+        return _error_response("Failed to acquire access token", code="AuthTokenUnavailable")
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    url = f"https://graph.microsoft.com/v1.0/users/{user_principal_name}/memberOf?{_GROUP_SELECT}"
+
+    aggregated: list[dict] = []
+    for payload, status_code in _iter_member_of(url, headers):
+        if status_code != 200:
+            return payload, status_code
+
+        if not isinstance(payload, dict):
+            logger.warning("Unexpected memberOf payload type: %s", type(payload))
+            continue
+
+        values = payload.get("value")
+        if isinstance(values, list):
+            aggregated.extend(item for item in values if isinstance(item, dict))
+
+    return {"value": aggregated}, 200

--- a/app-main/graph/services.py
+++ b/app-main/graph/services.py
@@ -1,7 +1,11 @@
 # azure/services.py
 from .scripts.graph_apicall_runhuntingquery import run_hunting_query
 from .scripts.graph_apicall_getuser import get_user
-from .scripts.graph_apicall_listuserauthenticationmethods import list_user_authentication_methods
+from .scripts.graph_apicall_getuserphoto import get_user_photo
+from .scripts.graph_apicall_listuserauthenticationmethods import (
+    list_user_authentication_methods,
+)
+from .scripts.graph_apicall_listusergroups import list_user_groups
 from .scripts.graph_apicall_deletemfa import microsoft_authentication_method
 from .scripts.graph_apicall_deletephone import phone_authentication_method
 from .scripts.graph_apicall_deletesoftwaremfa import delete_software_mfa_method  # Import the new method
@@ -19,6 +23,14 @@ def execute_get_user(user_principal_name, select_parameters):
 def execute_list_user_authentication_methods(user_id):
     response, status_code = list_user_authentication_methods(user_id)
     return response.json(), status_code
+
+
+def execute_list_user_groups(user_principal_name):
+    return list_user_groups(user_principal_name)
+
+
+def execute_get_user_photo(user_principal_name):
+    return get_user_photo(user_principal_name)
 
 
 def execute_phone_authentication_method(azure_user_principal_id ,authentication_method_id):

--- a/app-main/myview/static/myview/css/mfa-reset.css
+++ b/app-main/myview/static/myview/css/mfa-reset.css
@@ -16,6 +16,34 @@
     margin-bottom: 0.5rem;
 }
 
+.user-details-card {
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.05);
+}
+
+.user-details-card .user-photo {
+    width: 96px;
+    height: 96px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.user-photo-placeholder {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    background-color: #f0f0f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.875rem;
+    border: 1px dashed #d0d0d0;
+}
+
+.user-group-list .list-group-item {
+    padding-left: 0;
+    padding-right: 0;
+}
+
 /* Allow the tooltip used in the label to expand when necessary */
 .tooltip-inner {
     max-width: none;

--- a/app-main/myview/templates/myview/mfa-reset.html
+++ b/app-main/myview/templates/myview/mfa-reset.html
@@ -58,6 +58,87 @@
         </div>
     {% endif %}
 
+
+    {% if user_profile %}
+        <div class="card mb-4 user-details-card">
+            <div class="card-body">
+                <div class="row g-3 align-items-center">
+                    <div class="col-auto">
+                        {% if user_photo_url %}
+                            <img src="{{ user_photo_url }}" alt="{% trans 'User profile photo' %}" class="user-photo img-thumbnail">
+                        {% else %}
+                            <div class="user-photo-placeholder text-muted">{% trans 'No photo' %}</div>
+                        {% endif %}
+                    </div>
+                    <div class="col">
+                        <h4 class="mb-1">{{ user_profile.display_name|default:selected_user_principal_name }}</h4>
+                        {% if user_profile.job_title or user_profile.department %}
+                            <p class="mb-1 text-muted small">
+                                {% if user_profile.job_title %}{{ user_profile.job_title }}{% endif %}
+                                {% if user_profile.job_title and user_profile.department %}<span class="mx-1">·</span>{% endif %}
+                                {% if user_profile.department %}{{ user_profile.department }}{% endif %}
+                            </p>
+                        {% endif %}
+                        <dl class="row mb-0 small">
+                            {% if user_profile.email %}
+                                <dt class="col-sm-4">{% trans "Email" %}</dt>
+                                <dd class="col-sm-8"><a href="mailto:{{ user_profile.email }}">{{ user_profile.email }}</a></dd>
+                            {% endif %}
+                            {% if user_profile.user_principal_name and user_profile.email != user_profile.user_principal_name %}
+                                <dt class="col-sm-4">{% trans "User Principal Name" %}</dt>
+                                <dd class="col-sm-8">{{ user_profile.user_principal_name }}</dd>
+                            {% endif %}
+                            {% if user_profile.ou %}
+                                <dt class="col-sm-4">{% trans "Organizational unit" %}</dt>
+                                <dd class="col-sm-8">{{ user_profile.ou }}</dd>
+                            {% endif %}
+                            {% if user_profile.office_location %}
+                                <dt class="col-sm-4">{% trans "Office" %}</dt>
+                                <dd class="col-sm-8">{{ user_profile.office_location }}</dd>
+                            {% endif %}
+                            {% if user_profile.business_phones %}
+                                <dt class="col-sm-4">{% trans "Business phone" %}</dt>
+                                <dd class="col-sm-8">{{ user_profile.business_phones|join:', ' }}</dd>
+                            {% endif %}
+                            {% if user_profile.mobile_phone %}
+                                <dt class="col-sm-4">{% trans "Mobile" %}</dt>
+                                <dd class="col-sm-8">{{ user_profile.mobile_phone }}</dd>
+                            {% endif %}
+                            {% if user_profile.employee_id %}
+                                <dt class="col-sm-4">{% trans "Employee ID" %}</dt>
+                                <dd class="col-sm-8">{{ user_profile.employee_id }}</dd>
+                            {% endif %}
+                        </dl>
+                    </div>
+                </div>
+
+                {% if user_groups %}
+                    <div class="mt-3">
+                        <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#userGroupsCollapse" aria-expanded="false" aria-controls="userGroupsCollapse">
+                            {% blocktrans with count=user_groups|length %}Group memberships ({{ count }}){% endblocktrans %}
+                        </button>
+                        <div class="collapse mt-2" id="userGroupsCollapse">
+                            <ul class="list-group list-group-flush user-group-list">
+                                {% for group in user_groups %}
+                                    <li class="list-group-item">
+                                        <div class="fw-semibold">{{ group.display_name }}</div>
+                                        {% if group.mail or group.ou %}
+                                            <div class="small text-muted">
+                                                {% if group.mail %}<span>{{ group.mail }}</span>{% endif %}
+                                                {% if group.mail and group.ou %}<span class="mx-1">·</span>{% endif %}
+                                                {% if group.ou %}<span>{{ group.ou }}</span>{% endif %}
+                                            </div>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+
     {% if authentication_methods %}
         <div class="mb-4">
             {% if has_deletable_methods and bulk_delete_form %}


### PR DESCRIPTION
## Summary
- show user profile information, an expandable group membership list, and a profile photo on the MFA reset results card
- add Graph service helpers to retrieve user details, group memberships, and photos with a DTU-basen fallback
- style the new user details panel for consistent layout

## Testing
- python -m compileall app-main/myview/views.py app-main/graph/services.py app-main/graph/scripts/graph_apicall_listusergroups.py app-main/graph/scripts/graph_apicall_getuserphoto.py

------
https://chatgpt.com/codex/tasks/task_e_68ecffd34b5c832cba1cdad44c156e69