### PR TITLE
Enable Azure AD token auth for API and update MSAL frontend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,12 @@ developing.
 - Do not provide bearer tokens via environment variables anymore; any legacy `*_ACCESS_BEARER_TOKEN` values are ignored except for a one-time bootstrap into the database at startup.
 - You can proactively generate and persist tokens by running: `python app-main/manage.py refresh_service_tokens` (optionally pass `--service graph` or `--service defender`).
 
+## Azure AD frontend integration
+
+- API endpoints now accept Microsoft Entra ID access tokens issued for the frontend SPA. Configure one of `AZURE_API_AUDIENCE` or `AZURE_API_CLIENT_ID` so Django can validate the `aud` claim. If neither is provided, the value falls back to the confidential client ID used for the legacy login flow.
+- Specify the allowed browser origins with `DJANGO_CORS_ALLOWED_ORIGINS` (comma separated). By default the API allows `http://localhost:3030`, `http://127.0.0.1:3030`, and `https://view.security.ait.dtu.dk`.
+- Optional: `AZURE_AD_LEEWAY_SECONDS` can be used to relax clock drift for token validation (default 120 seconds).
+
 ## Deploying with Coolify + Traefik
 
 A detailed, step-by-step deployment walkthrough is available in

--- a/backend/app-main/active_directory/views.py
+++ b/backend/app-main/active_directory/views.py
@@ -10,10 +10,11 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from ldap3 import ALL_ATTRIBUTES
 from rest_framework import status
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
 
 from utils.api import SecuredAPIView
+from utils.authentication import AzureAdTokenAuthentication
+from rest_framework.authentication import TokenAuthentication
 
 from .services import (
     execute_active_directory_query,
@@ -24,7 +25,7 @@ from .services import (
 class ActiveDirectoryQueryAssistantView(SecuredAPIView):
     """Assist in building Active Directory queries from natural language."""
 
-    authentication_classes = [TokenAuthentication]
+    authentication_classes = [AzureAdTokenAuthentication, TokenAuthentication]
 
     header_parameter = openapi.Parameter(
         "Authorization",

--- a/backend/app-main/app/settings.py
+++ b/backend/app-main/app/settings.py
@@ -221,6 +221,36 @@ AZURE_AD = {
     'SCOPE': ['User.Read']  # Add other scopes if needed
 }
 
+_azure_audience = os.getenv('AZURE_API_AUDIENCE') or os.getenv('AZURE_API_CLIENT_ID')
+_azure_client_id = AZURE_AD.get('CLIENT_ID')
+
+_audience_candidates = [
+    _azure_audience,
+    f"api://{_azure_audience}" if _azure_audience and not _azure_audience.startswith('api://') else None,
+    _azure_client_id,
+    f"api://{_azure_client_id}" if _azure_client_id else None,
+]
+
+AZURE_AD_ALLOWED_AUDIENCES = tuple(
+    dict.fromkeys(filter(None, _audience_candidates))
+)
+
+_tenant_for_issuers = AZURE_AD.get('TENANT_ID') or os.getenv('AZURE_TENANT_ID')
+AZURE_AD_ALLOWED_ISSUERS = tuple(
+    filter(
+        None,
+        [
+            f"https://login.microsoftonline.com/{_tenant_for_issuers}/v2.0" if _tenant_for_issuers else None,
+            f"https://sts.windows.net/{_tenant_for_issuers}/" if _tenant_for_issuers else None,
+        ],
+    )
+)
+
+try:
+    AZURE_AD_LEEWAY_SECONDS = int(os.getenv('AZURE_AD_LEEWAY_SECONDS', '120'))
+except ValueError:
+    AZURE_AD_LEEWAY_SECONDS = 120
+
 AZURE_GRAPH_REQUEST_TIMEOUT = _as_float(
     os.getenv('AZURE_GRAPH_TIMEOUT'),
     10.0,
@@ -271,6 +301,19 @@ else:
     ALLOWED_HOSTS = default_allowed_hosts
 
 
+cors_origins_env = os.getenv('DJANGO_CORS_ALLOWED_ORIGINS')
+if cors_origins_env:
+    CORS_ALLOWED_ORIGINS = [origin.strip() for origin in cors_origins_env.split(',') if origin.strip()]
+else:
+    CORS_ALLOWED_ORIGINS = [
+        'http://localhost:3030',
+        'http://127.0.0.1:3030',
+        'https://view.security.ait.dtu.dk',
+    ]
+
+CORS_ALLOW_CREDENTIALS = False
+
+
 default_csrf_domain = os.getenv('DJANGO_CSRF_COOKIE_DOMAIN')
 if default_csrf_domain is not None:
     CSRF_COOKIE_DOMAIN = default_csrf_domain or None
@@ -312,6 +355,7 @@ INSTALLED_APPS = [
     'django_extensions',
     'rest_framework',
     'rest_framework.authtoken',
+    'corsheaders',
     'sccm',
     'drf_yasg',
     'myview',
@@ -327,6 +371,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -562,6 +607,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'utils.authentication.AzureAdTokenAuthentication',
     ),
 }
 

--- a/backend/app-main/misc/views.py
+++ b/backend/app-main/misc/views.py
@@ -1,12 +1,13 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
 from datetime import datetime
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
+from utils.authentication import AzureAdTokenAuthentication
+from rest_framework.authentication import TokenAuthentication
 
 class JsonValueExtractor(viewsets.ViewSet):
 
-    authentication_classes = [TokenAuthentication]  # Require token authentication for this view
+    authentication_classes = [AzureAdTokenAuthentication, TokenAuthentication]  # Require token authentication for this view
     permission_classes = [IsAuthenticated]  # Require authenticated user for this view
 
 

--- a/backend/app-main/playbook/views.py
+++ b/backend/app-main/playbook/views.py
@@ -1,16 +1,17 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
 from datetime import datetime
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from graph.services import execute_hunting_query
 import pytz
+from utils.authentication import AzureAdTokenAuthentication
+from rest_framework.authentication import TokenAuthentication
 
 
 class MyMFARejectedByUser(viewsets.ViewSet):
 
     # require authentication
-    authentication_classes = [TokenAuthentication]  # Require token authentication for this view
+    authentication_classes = [AzureAdTokenAuthentication, TokenAuthentication]  # Require token authentication for this view
     permission_classes = [IsAuthenticated]  # Require authenticated user for this view
 
     def get_email(self, request, *args, **kwargs):

--- a/backend/app-main/requirements.txt
+++ b/backend/app-main/requirements.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 cryptography==44.0.3
 Deprecated==1.2.14
 Django==4.2.25
+django-cors-headers==4.6.0
 django-cas-ng==4.3.0
 django-extensions==3.2.3
 djangorestframework==3.15.2

--- a/backend/app-main/sccm/views.py
+++ b/backend/app-main/sccm/views.py
@@ -4,14 +4,18 @@ from .models import Item
 from .serializers import ItemSerializer, ComputerInfoSerializer
 from sccm.scripts.sccm_get_computer_info import get_computer_info
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from drf_yasg import openapi
+from utils.authentication import AzureAdTokenAuthentication
+from rest_framework.authentication import TokenAuthentication
 
 
 
 
 class SCCMViewSet_1_0_1(viewsets.ViewSet):
+
+    authentication_classes = [AzureAdTokenAuthentication, TokenAuthentication]
+    permission_classes = [IsAuthenticated]
 
 
     header_parameter = openapi.Parameter(
@@ -45,10 +49,6 @@ class SCCMViewSet_1_0_1(viewsets.ViewSet):
     )
 
     def get_computerinfo(self, request, computer_name=None):
-
-        authentication_classes = [TokenAuthentication]  # Require token authentication for this view
-        permission_classes = [IsAuthenticated]  # Require authenticated user for this view
-
 
         # Check if the computer_name is None, or is an empty string, or with only spaces
         if computer_name is None or computer_name.strip() == "":

--- a/backend/app-main/utils/api.py
+++ b/backend/app-main/utils/api.py
@@ -11,6 +11,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .authentication import AzureAdTokenAuthentication
 logger = logging.getLogger(__name__)
 
 
@@ -24,7 +25,7 @@ class SecuredAPIView(APIView):
     runtime behaviour.
     """
 
-    authentication_classes = [SessionAuthentication, TokenAuthentication]
+    authentication_classes = [SessionAuthentication, TokenAuthentication, AzureAdTokenAuthentication]
 
     def finalize_response(  # type: ignore[override]
         self,

--- a/backend/app-main/utils/authentication.py
+++ b/backend/app-main/utils/authentication.py
@@ -1,0 +1,206 @@
+"""Authentication helpers for validating Azure AD access tokens."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, Iterable, Optional
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from jwt import PyJWKClient, PyJWKClientError
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication, get_authorization_header
+
+logger = logging.getLogger(__name__)
+
+
+class AzureAdTokenAuthentication(BaseAuthentication):
+    """Authenticate requests carrying a Microsoft Entra ID bearer token.
+
+    The class validates the JWT using the tenant's JWKS endpoint and maps the
+    token claims to a Django ``User`` instance.  Users are created on the fly
+    using the Azure AD username so existing permission checks based on
+    ``request.user`` continue to work once the frontend authenticates with
+    MSAL.
+    """
+
+    _jwks_cache: Dict[str, tuple[PyJWKClient, float]] = {}
+    _jwks_cache_ttl = 60 * 60  # 1 hour
+
+    def authenticate(self, request):  # type: ignore[override]
+        authorization = get_authorization_header(request).split()
+        if not authorization:
+            return None
+
+        if authorization[0].lower() != b"bearer":
+            return None
+
+        if len(authorization) == 1:
+            raise exceptions.AuthenticationFailed(
+                "Invalid Authorization header. No credentials provided.",
+            )
+
+        if len(authorization) > 2:
+            raise exceptions.AuthenticationFailed(
+                "Invalid Authorization header. Token string should not contain spaces.",
+            )
+
+        token = authorization[1].decode("utf-8")
+
+        claims = self._validate_token(token)
+        user = self._get_or_create_user(claims)
+
+        # Expose claims on the request for downstream consumers if needed.
+        setattr(request, "azure_ad_claims", claims)
+
+        return user, claims
+
+    # ------------------------------------------------------------------
+    # Token validation helpers
+    # ------------------------------------------------------------------
+    def _validate_token(self, token: str) -> Dict[str, Any]:
+        config = getattr(settings, "AZURE_AD", {}) or {}
+        tenant_id = config.get("TENANT_ID") or os.getenv("AZURE_TENANT_ID")
+        if not tenant_id:
+            logger.error("Azure AD tenant ID is not configured.")
+            raise exceptions.AuthenticationFailed("Azure AD authentication is not configured.")
+
+        audiences: Iterable[str] = getattr(settings, "AZURE_AD_ALLOWED_AUDIENCES", ())
+        issuers: Iterable[str] = getattr(settings, "AZURE_AD_ALLOWED_ISSUERS", ())
+        leeway: int = getattr(settings, "AZURE_AD_LEEWAY_SECONDS", 120)
+
+        jwks_client = self._get_jwks_client(tenant_id)
+        try:
+            signing_key = jwks_client.get_signing_key_from_jwt(token)
+        except PyJWKClientError as exc:
+            logger.warning("Failed to resolve Azure AD signing key: %s", exc)
+            # Invalidate the cache and retry once. This handles key rotation.
+            self._invalidate_jwks_client(tenant_id)
+            try:
+                signing_key = self._get_jwks_client(tenant_id).get_signing_key_from_jwt(token)
+            except PyJWKClientError as retry_exc:
+                raise exceptions.AuthenticationFailed("Unable to validate Azure AD token signature.") from retry_exc
+
+        decode_kwargs: Dict[str, Any] = {
+            "algorithms": ["RS256"],
+            "options": {"verify_aud": bool(audiences)},
+            "leeway": leeway,
+        }
+
+        if audiences:
+            # Remove duplicates while preserving order
+            audience_list = list(dict.fromkeys(audiences))
+            decode_kwargs["audience"] = audience_list
+
+        try:
+            claims = jwt.decode(token, signing_key.key, **decode_kwargs)
+        except jwt.InvalidTokenError as exc:  # pragma: no cover - defensive
+            logger.warning("Azure AD token validation failed: %s", exc)
+            raise exceptions.AuthenticationFailed("Invalid Azure AD access token.") from exc
+
+        issuer = str(claims.get("iss", ""))
+        if issuers and issuer not in issuers:
+            logger.warning("Rejected Azure AD token with unexpected issuer: %s", issuer)
+            raise exceptions.AuthenticationFailed("Token issuer is not allowed.")
+
+        token_tenant = str(claims.get("tid", "")).lower()
+        if token_tenant and token_tenant != tenant_id.lower():
+            logger.warning("Rejected Azure AD token from tenant %s", token_tenant)
+            raise exceptions.AuthenticationFailed("Token tenant does not match configuration.")
+
+        return claims
+
+    @classmethod
+    def _get_jwks_client(cls, tenant_id: str) -> PyJWKClient:
+        cached = cls._jwks_cache.get(tenant_id)
+        now = time.time()
+        if cached and (now - cached[1]) < cls._jwks_cache_ttl:
+            return cached[0]
+
+        jwks_uri = f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
+        client = PyJWKClient(jwks_uri, cache_keys=True)
+        cls._jwks_cache[tenant_id] = (client, now)
+        return client
+
+    @classmethod
+    def _invalidate_jwks_client(cls, tenant_id: str) -> None:
+        cls._jwks_cache.pop(tenant_id, None)
+
+    # ------------------------------------------------------------------
+    # User management helpers
+    # ------------------------------------------------------------------
+    def _get_or_create_user(self, claims: Dict[str, Any]):
+        username_source = (
+            claims.get("preferred_username")
+            or claims.get("upn")
+            or claims.get("email")
+            or claims.get("unique_name")
+        )
+
+        if not username_source:
+            raise exceptions.AuthenticationFailed("Azure AD token did not include a username claim.")
+
+        username_source = str(username_source).strip()
+        if not username_source:
+            raise exceptions.AuthenticationFailed("Azure AD username claim was empty.")
+
+        email = username_source.lower()
+        username = email.split("@")[0] if "@" in email else email
+        username = username.strip()
+        if not username:
+            raise exceptions.AuthenticationFailed("Unable to determine username from Azure AD token.")
+
+        User = get_user_model()
+
+        user = User.objects.filter(username__iexact=username).first()
+        if user is None and email:
+            user = User.objects.filter(email__iexact=email).first()
+
+        defaults: Dict[str, Optional[str]] = {
+            "email": email or None,
+        }
+
+        given_name = claims.get("given_name")
+        family_name = claims.get("family_name")
+        display_name = claims.get("name")
+
+        if given_name:
+            defaults["first_name"] = str(given_name)
+        if family_name:
+            defaults["last_name"] = str(family_name)
+        elif display_name and not family_name:
+            parts = str(display_name).split(" ", 1)
+            if parts:
+                defaults.setdefault("first_name", parts[0])
+            if len(parts) > 1:
+                defaults["last_name"] = parts[1]
+
+        if user is None:
+            user = User(username=username)
+            for field, value in defaults.items():
+                if value:
+                    setattr(user, field, value)
+            if hasattr(user, "set_unusable_password"):
+                user.set_unusable_password()
+            if hasattr(user, "is_active") and not user.is_active:
+                user.is_active = True
+            user.save()
+            logger.info("Created Django user %s from Azure AD token", username)
+            return user
+
+        update_fields = []
+        for field, value in defaults.items():
+            if value and getattr(user, field, None) != value:
+                setattr(user, field, value)
+                update_fields.append(field)
+
+        if update_fields:
+            user.save(update_fields=update_fields)
+
+        return user
+
+
+__all__ = ["AzureAdTokenAuthentication"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,11 @@
-import { useAuth } from './hooks/useAuth'
-import LoginPage from './components/LoginPage'
-import Dashboard from './components/Dashboard'
-import './styles/App.css'
+import { useAuth } from './hooks/useAuth';
+import LoginPage from './components/LoginPage';
+import Dashboard from './components/Dashboard';
+import './styles/App.css';
 
 function App() {
-  // Use our custom authentication hook
   const { isAuthenticated, isLoading } = useAuth();
 
-  // Show loading spinner while checking authentication
   if (isLoading) {
     return (
       <div className="loading-container">
@@ -19,7 +17,6 @@ function App() {
     );
   }
 
-  // Show login page or dashboard based on authentication status
   return (
     <div className="App">
       {isAuthenticated ? <Dashboard /> : <LoginPage />}
@@ -27,4 +24,4 @@ function App() {
   );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/ApiTestPage.tsx
+++ b/frontend/src/components/ApiTestPage.tsx
@@ -46,8 +46,8 @@ const ApiTestPage: React.FC<ApiTestPageProps> = ({ accessToken, onClose }) => {
     setResponse(null);
 
     try {
-      const apiUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
-      const fullUrl = `${apiUrl}/api/breached-account/${encodeURIComponent(email)}`;
+      const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
+      const fullUrl = `${apiBaseUrl}/hibp/v3/breachedaccount/${encodeURIComponent(email)}`;
       
       console.log('Calling API endpoint:', fullUrl);
       

--- a/frontend/src/components/ResetMFAModal.tsx
+++ b/frontend/src/components/ResetMFAModal.tsx
@@ -34,8 +34,8 @@ const ResetMFAModal: React.FC<ResetMFAModalProps> = ({ onClose, accessToken }) =
     try {
       console.log('🔄 Resetting MFA for user:', username);
       
-      // TODO: Replace with actual API endpoint when your colleague implements it
-      const response = await fetch('/api/auth/reset-mfa', {
+      const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
+      const response = await fetch(`${apiBaseUrl}/api/auth/reset-mfa`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/utils/apiTester.ts
+++ b/frontend/src/utils/apiTester.ts
@@ -1,107 +1,131 @@
 // API Testing Utility
-// This utility helps test API endpoints using the saved API key
+// This utility helps test API endpoints using the authenticated access token
 
 export interface ApiTestResult {
   success: boolean;
   status: number;
   message: string;
-  data?: any;
+  data?: unknown;
   error?: string;
 }
 
-export class ApiTester {
-  private apiKey: string;
-  private baseUrl: string = 'https://api.security.ait.dtu.dk';
+const DEFAULT_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/$/, '');
 
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
+export class ApiTester {
+  private accessToken: string;
+  private baseUrl: string;
+
+  constructor(accessToken: string, baseUrl: string = DEFAULT_BASE_URL) {
+    this.accessToken = accessToken;
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  private get authorizationHeader(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.accessToken}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private getPreferredUsername(): string | null {
+    try {
+      const [, payload] = this.accessToken.split('.');
+      if (!payload) {
+        return null;
+      }
+
+      const decoded = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+      return decoded.preferred_username || decoded.upn || decoded.email || null;
+    } catch (error) {
+      console.warn('Unable to read preferred username from token payload', error);
+      return null;
+    }
   }
 
   // Test basic API connectivity
   async testConnection(): Promise<ApiTestResult> {
     try {
-      console.log('🔗 Testing API connection...');
-      
-      const response = await fetch(`${this.baseUrl}/health`, {
+      const response = await fetch(`${this.baseUrl}/healthz/`, {
         method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
+        headers: this.authorizationHeader,
       });
 
-      const data = await response.json();
+      const data = await response.json().catch(() => null);
 
       if (response.ok) {
         return {
           success: true,
           status: response.status,
           message: 'API connection successful',
-          data: data,
-        };
-      } else {
-        return {
-          success: false,
-          status: response.status,
-          message: 'API connection failed',
-          error: data.message || 'Unknown error',
+          data,
         };
       }
+
+      return {
+        success: false,
+        status: response.status,
+        message: 'API connection failed',
+        error: (data as Record<string, string> | null)?.message || response.statusText,
+      };
     } catch (error: any) {
       console.error('API test failed:', error);
       return {
         success: false,
         status: 0,
         message: 'Network error',
-        error: error.message,
+        error: error?.message ?? 'Unknown error',
       };
     }
   }
 
-  // Test user profile endpoint
+  // Test Microsoft Graph proxy endpoint by requesting the current user
   async testUserProfile(): Promise<ApiTestResult> {
+    const preferredUsername = this.getPreferredUsername();
+    if (!preferredUsername) {
+      return {
+        success: false,
+        status: 0,
+        message: 'Unable to determine username from access token',
+        error: 'Token payload missing preferred_username/upn/email claim',
+      };
+    }
+
     try {
-      console.log('👤 Testing user profile endpoint...');
-      
-      const response = await fetch(`${this.baseUrl}/api/user/profile`, {
+      const encodedUser = encodeURIComponent(preferredUsername);
+      const response = await fetch(`${this.baseUrl}/graph/v1.0/get-user/${encodedUser}`, {
         method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-        },
+        headers: this.authorizationHeader,
       });
 
-      const data = await response.json();
+      const data = await response.json().catch(() => null);
 
       if (response.ok) {
         return {
           success: true,
           status: response.status,
           message: 'User profile retrieved successfully',
-          data: data,
-        };
-      } else {
-        return {
-          success: false,
-          status: response.status,
-          message: 'Failed to retrieve user profile',
-          error: data.message || 'Unknown error',
+          data,
         };
       }
+
+      return {
+        success: false,
+        status: response.status,
+        message: 'Failed to retrieve user profile',
+        error: (data as Record<string, string> | null)?.message || response.statusText,
+      };
     } catch (error: any) {
       return {
         success: false,
         status: 0,
         message: 'Network error',
-        error: error.message,
+        error: error?.message ?? 'Unknown error',
       };
     }
   }
 
   // Run a comprehensive test suite
   async runTestSuite(): Promise<ApiTestResult[]> {
-    console.log('🧪 Running API test suite...');
-    
     const tests = [
       { name: 'Connection Test', test: () => this.testConnection() },
       { name: 'User Profile Test', test: () => this.testUserProfile() },
@@ -110,12 +134,11 @@ export class ApiTester {
     const results: ApiTestResult[] = [];
 
     for (const test of tests) {
-      console.log(`Running ${test.name}...`);
+      // eslint-disable-next-line no-await-in-loop
       const result = await test.test();
       results.push(result);
-      
-      // Wait a bit between tests to be nice to the server
-      await new Promise(resolve => setTimeout(resolve, 500));
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, 500));
     }
 
     return results;


### PR DESCRIPTION
## Summary
- add an Azure AD bearer-token authentication backend and use it across secured API views
- expose CORS configuration and document the new Azure AD settings
- update the frontend MSAL client to call the API with access tokens and adjust supporting utilities

## Testing
- python manage.py check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6901ff76b284832ca6117123a063566d