### PR TITLE
Add embedded Swagger UI modal to dashboard

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import ApiTestPage from './ApiTestPage';
 import ResetMFAModal from './ResetMFAModal';
+import SwaggerDocsModal from './SwaggerDocsModal';
 import UnfamiliarLoginPage from './UnfamiliarLoginPage';
 import './Dashboard.css';
 
@@ -18,6 +19,7 @@ const Dashboard: React.FC = () => {
   const [showApiTestPage, setShowApiTestPage] = useState<boolean>(false);
   const [showUnfamiliarLogin, setShowUnfamiliarLogin] = useState<boolean>(false);
   const [showMFAModal, setShowMFAModal] = useState<boolean>(false);
+  const [showSwaggerDocs, setShowSwaggerDocs] = useState<boolean>(false);
   const [authStatus, setAuthStatus] = useState<'ready' | 'checking' | 'expired'>('checking');
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [backendApiToken, setBackendApiToken] = useState<string | null>(null);
@@ -118,6 +120,10 @@ const Dashboard: React.FC = () => {
 
   const handleMFAReset = () => {
     setShowMFAModal(true);
+  };
+
+  const handleSwaggerDocs = () => {
+    setShowSwaggerDocs(true);
   };
 
   const handleViewDocs = () => {
@@ -253,6 +259,13 @@ const Dashboard: React.FC = () => {
               <p>Browse complete API documentation and examples</p>
             </div>
 
+            {/* Swagger UI Card */}
+            <div className="card" onClick={handleSwaggerDocs}>
+              <div className="card-icon">🧭</div>
+              <h3>Swagger UI</h3>
+              <p>Open backend Swagger docs in an embedded viewer</p>
+            </div>
+
             {/* Check Unfamiliar Login Card */}
             <div className={`card ${authStatus !== 'ready' ? 'disabled' : ''}`} onClick={handleUnfamiliarLogin}>
               <div className="card-icon">🔍</div>
@@ -306,6 +319,14 @@ const Dashboard: React.FC = () => {
         <ResetMFAModal
           accessToken={accessToken}
           onClose={() => setShowMFAModal(false)}
+        />
+      )}
+
+      {/* Swagger Docs Modal */}
+      {showSwaggerDocs && (
+        <SwaggerDocsModal
+          accessToken={accessToken}
+          onClose={() => setShowSwaggerDocs(false)}
         />
       )}
     </div>

--- a/frontend/src/components/SwaggerDocsModal.css
+++ b/frontend/src/components/SwaggerDocsModal.css
@@ -1,0 +1,116 @@
+.swagger-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 1000;
+}
+
+.swagger-modal-content {
+  background: rgba(255, 255, 255, 0.97);
+  border-radius: 18px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+  width: min(1200px, 100%);
+  height: min(90vh, 800px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.swagger-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem 1.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.swagger-modal-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #1e293b;
+}
+
+.swagger-modal-header p {
+  margin: 0.35rem 0 0 0;
+  color: #475569;
+  font-size: 0.95rem;
+  max-width: 32rem;
+}
+
+.swagger-modal-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.swagger-open-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.swagger-open-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(102, 126, 234, 0.35);
+}
+
+.swagger-close-button {
+  background: transparent;
+  border: none;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #475569;
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.swagger-close-button:hover {
+  background-color: rgba(148, 163, 184, 0.15);
+  color: #1e293b;
+}
+
+.swagger-iframe-container {
+  flex: 1;
+  margin: 0 1.75rem 1.75rem 1.75rem;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(100, 116, 139, 0.2);
+  background: white;
+}
+
+.swagger-iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+@media (max-width: 768px) {
+  .swagger-modal-content {
+    padding: 0;
+  }
+
+  .swagger-modal-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .swagger-modal-actions {
+    justify-content: space-between;
+  }
+}

--- a/frontend/src/components/SwaggerDocsModal.tsx
+++ b/frontend/src/components/SwaggerDocsModal.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react';
+import './SwaggerDocsModal.css';
+
+interface SwaggerDocsModalProps {
+  accessToken: string | null;
+  onClose: () => void;
+}
+
+const SWAGGER_BASE_URL = 'https://api.security.ait.dtu.dk/myview/swagger/';
+
+const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClose }) => {
+  const swaggerUrl = useMemo(() => {
+    if (!accessToken) {
+      return SWAGGER_BASE_URL;
+    }
+
+    const url = new URL(SWAGGER_BASE_URL);
+    url.searchParams.set('access_token', accessToken);
+    return url.toString();
+  }, [accessToken]);
+
+  const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="swagger-modal-overlay" onClick={handleOverlayClick}>
+      <div className="swagger-modal-content">
+        <header className="swagger-modal-header">
+          <div>
+            <h2>📘 Backend Swagger UI</h2>
+            <p>
+              Explore and test the backend API endpoints directly from the embedded Swagger UI.
+            </p>
+          </div>
+          <div className="swagger-modal-actions">
+            <a
+              className="swagger-open-link"
+              href={swaggerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open in new tab
+            </a>
+            <button className="swagger-close-button" onClick={onClose} aria-label="Close swagger modal">
+              ×
+            </button>
+          </div>
+        </header>
+        <div className="swagger-iframe-container">
+          <iframe
+            src={swaggerUrl}
+            title="Backend Swagger Documentation"
+            className="swagger-iframe"
+            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SwaggerDocsModal;


### PR DESCRIPTION
## Summary
- add a Swagger UI card to the security tools dashboard
- implement an embedded Swagger modal with iframe access to the backend documentation and styling

## Testing
- npm run build *(fails: existing TypeScript errors in UnfamiliarLoginPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6903b9955110832cafa6c6e17dbc6488