### PR TITLE
Replace dashboard backend token form with API token controls

### DIFF
--- a/frontend/src/components/Dashboard.css
+++ b/frontend/src/components/Dashboard.css
@@ -165,11 +165,26 @@
   border: 1px solid rgba(239, 68, 68, 0.3);
 }
 
+.token-status-pill--loading {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
 .token-section-hint {
   margin: 12px 0 0 0;
   color: #4a5568;
   font-size: 14px;
   line-height: 1.5;
+}
+
+.token-section-hint code {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 13px;
+  color: #1e3a8a;
 }
 
 .token-form {
@@ -219,6 +234,13 @@
   transform: translateY(-1px);
 }
 
+.token-toggle:disabled {
+  cursor: not-allowed;
+  background: rgba(99, 102, 241, 0.12);
+  color: rgba(76, 81, 191, 0.6);
+  transform: none;
+}
+
 .token-actions {
   display: flex;
   flex-wrap: wrap;
@@ -254,6 +276,17 @@
 
 .token-button.secondary:hover:not(:disabled) {
   background: rgba(102, 126, 234, 0.18);
+  transform: translateY(-2px);
+}
+
+.token-button.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.token-button.danger:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.25);
   transform: translateY(-2px);
 }
 
@@ -294,10 +327,23 @@
   margin-top: 12px;
   padding: 12px 16px;
   border-radius: 10px;
-  background: rgba(16, 185, 129, 0.15);
-  color: #047857;
   font-weight: 500;
   font-size: 13px;
+}
+
+.token-feedback--success {
+  background: rgba(16, 185, 129, 0.15);
+  color: #047857;
+}
+
+.token-feedback--error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.token-feedback--info {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,14 +1,13 @@
 // Dashboard Component - Clean and Simple
 // Simple interface for API Security tools using Azure AD authentication
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import ApiTestPage from './ApiTestPage';
 import ResetMFAModal from './ResetMFAModal';
 import UnfamiliarLoginPage from './UnfamiliarLoginPage';
 import './Dashboard.css';
-
-const BACKEND_API_TOKEN_KEY = 'myview.backendApiToken';
+import { buildBearerToken, resolveApiBaseUrl } from '../utils/apiBaseUrl';
 
 const Dashboard: React.FC = () => {
   // Use our custom authentication hook
@@ -20,10 +19,13 @@ const Dashboard: React.FC = () => {
   const [showMFAModal, setShowMFAModal] = useState<boolean>(false);
   const [authStatus, setAuthStatus] = useState<'ready' | 'checking' | 'expired'>('checking');
   const [accessToken, setAccessToken] = useState<string | null>(null);
-  const [backendApiToken, setBackendApiToken] = useState<string | null>(null);
-  const [tokenInput, setTokenInput] = useState('');
-  const [isTokenVisible, setIsTokenVisible] = useState(false);
-  const [tokenFeedback, setTokenFeedback] = useState<string | null>(null);
+  const [apiToken, setApiToken] = useState<string | null>(null);
+  const [isApiTokenVisible, setIsApiTokenVisible] = useState(false);
+  const [isFetchingApiToken, setIsFetchingApiToken] = useState(false);
+  const [isRotatingApiToken, setIsRotatingApiToken] = useState(false);
+  const [apiTokenFeedback, setApiTokenFeedback] = useState<
+    { message: string; tone: 'success' | 'error' | 'info' } | null
+  >(null);
 
   // Check authentication status when component mounts
   useEffect(() => {
@@ -47,28 +49,6 @@ const Dashboard: React.FC = () => {
 
     checkAuthStatus();
   }, [user, getAccessToken]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    const storedToken = window.localStorage.getItem(BACKEND_API_TOKEN_KEY);
-    if (storedToken) {
-      setBackendApiToken(storedToken);
-      setTokenInput(storedToken);
-    }
-  }, []);
-
-  const persistBackendToken = (token: string | null) => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    if (token) {
-      window.localStorage.setItem(BACKEND_API_TOKEN_KEY, token);
-    } else {
-      window.localStorage.removeItem(BACKEND_API_TOKEN_KEY);
-    }
-  };
 
   // Handlers
   const handleSignOut = async () => {
@@ -95,25 +75,135 @@ const Dashboard: React.FC = () => {
     setShowUnfamiliarLogin(true);
   };
 
-  const handleTokenSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const trimmed = tokenInput.trim();
-    if (trimmed) {
-      persistBackendToken(trimmed);
-      setBackendApiToken(trimmed);
-      setTokenFeedback('Token saved to this browser.');
-    } else {
-      persistBackendToken(null);
-      setBackendApiToken(null);
-      setTokenFeedback('Token cleared.');
+  const ensureAccessToken = useCallback(async (): Promise<string | null> => {
+    try {
+      const freshToken = await getAccessToken();
+      if (freshToken) {
+        setAccessToken(freshToken);
+        return freshToken;
+      }
+    } catch (error) {
+      console.error('❌ Failed to refresh access token:', error);
     }
-  };
 
-  const handleTokenClear = () => {
-    setTokenInput('');
-    persistBackendToken(null);
-    setBackendApiToken(null);
-    setTokenFeedback('Token cleared.');
+    if (accessToken) {
+      return accessToken;
+    }
+
+    return null;
+  }, [accessToken, getAccessToken]);
+
+  const handleFetchApiToken = useCallback(async () => {
+    setApiTokenFeedback(null);
+
+    const activeAccessToken = await ensureAccessToken();
+    if (!activeAccessToken) {
+      setApiToken(null);
+      setApiTokenFeedback({
+        message: 'No access token available. Please sign in again.',
+        tone: 'error'
+      });
+      return;
+    }
+
+    setIsFetchingApiToken(true);
+    try {
+      const baseUrl = resolveApiBaseUrl();
+      const response = await fetch(`${baseUrl}/myview/api/token/`, {
+        method: 'GET',
+        headers: {
+          Authorization: buildBearerToken(activeAccessToken),
+          Accept: 'application/json'
+        },
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || `Request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as { api_token?: string | null };
+      const token = payload?.api_token ?? null;
+
+      if (token) {
+        setApiToken(token);
+        setApiTokenFeedback({ message: 'API token loaded.', tone: 'success' });
+      } else {
+        setApiToken(null);
+        setApiTokenFeedback({
+          message: 'No API token found for your account.',
+          tone: 'info'
+        });
+      }
+    } catch (error) {
+      console.error('❌ Failed to load API token:', error);
+      setApiTokenFeedback({
+        message: 'Failed to load API token. Please try again.',
+        tone: 'error'
+      });
+    } finally {
+      setIsFetchingApiToken(false);
+    }
+  }, [ensureAccessToken]);
+
+  const handleRotateApiToken = useCallback(async () => {
+    setApiTokenFeedback(null);
+
+    const confirmed = window.confirm(
+      'Rotating your API token will immediately invalidate the previous token. Do you want to continue?'
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const activeAccessToken = await ensureAccessToken();
+    if (!activeAccessToken) {
+      setApiTokenFeedback({
+        message: 'No access token available. Please sign in again.',
+        tone: 'error'
+      });
+      return;
+    }
+
+    setIsRotatingApiToken(true);
+    try {
+      const baseUrl = resolveApiBaseUrl();
+      const response = await fetch(`${baseUrl}/myview/api/token/rotate/`, {
+        method: 'POST',
+        headers: {
+          Authorization: buildBearerToken(activeAccessToken),
+          Accept: 'application/json'
+        },
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || `Request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as { api_token?: string | null };
+      const token = payload?.api_token ?? null;
+      setApiToken(token);
+      setApiTokenFeedback({
+        message: 'API token rotated successfully.',
+        tone: 'success'
+      });
+    } catch (error) {
+      console.error('❌ Failed to rotate API token:', error);
+      setApiTokenFeedback({
+        message: 'Failed to rotate API token. Please try again.',
+        tone: 'error'
+      });
+    } finally {
+      setIsRotatingApiToken(false);
+    }
+  }, [ensureAccessToken]);
+
+  const handleToggleApiTokenVisibility = () => {
+    setIsApiTokenVisible(visible => !visible);
   };
 
   const handleMFAReset = () => {
@@ -139,6 +229,26 @@ const Dashboard: React.FC = () => {
       alert('No access token available');
     }
   };
+
+  useEffect(() => {
+    if (authStatus === 'ready') {
+      handleFetchApiToken();
+    }
+  }, [authStatus, handleFetchApiToken]);
+
+  const isApiTokenBusy = isFetchingApiToken || isRotatingApiToken;
+  const apiTokenStatusClass = isApiTokenBusy
+    ? 'token-status-pill--loading'
+    : apiToken
+      ? 'token-status-pill--ready'
+      : 'token-status-pill--missing';
+  const apiTokenStatusText = isRotatingApiToken
+    ? 'Rotating…'
+    : isFetchingApiToken
+      ? 'Loading…'
+      : apiToken
+        ? 'Ready'
+        : 'Not loaded';
 
   return (
     <div className="dashboard-container">
@@ -180,65 +290,64 @@ const Dashboard: React.FC = () => {
 
         <section className="token-section">
           <div className="token-section-header">
-            <h3>Backend API Token</h3>
-            <span className={`token-status-pill ${backendApiToken ? 'token-status-pill--ready' : 'token-status-pill--missing'}`}>
-              {backendApiToken ? 'Saved locally' : 'Not saved'}
+            <h3>API Token</h3>
+            <span className={`token-status-pill ${apiTokenStatusClass}`}>
+              {apiTokenStatusText}
             </span>
           </div>
           <p className="token-section-hint">
-            Paste the API token from the admin frontpage. It stays in this browser&apos;s local storage only.
+            Use this token in the Authorization header as <code>Token &lt;key&gt;</code> when calling the API. The token is fetched
+            using your Azure AD sign-in and is never stored in your browser.
           </p>
-          <form className="token-form" onSubmit={handleTokenSubmit}>
-            <div className="token-input-row">
-              <input
-                type={isTokenVisible ? 'text' : 'password'}
-                className="token-input"
-                value={tokenInput}
-                onChange={event => {
-                  setTokenInput(event.target.value);
-                  if (tokenFeedback) {
-                    setTokenFeedback(null);
-                  }
-                }}
-                placeholder="Enter backend API token"
-                autoComplete="off"
-                spellCheck={false}
-              />
-              <button
-                type="button"
-                className="token-toggle"
-                onClick={() => setIsTokenVisible(visible => !visible)}
-                aria-label={isTokenVisible ? 'Hide token' : 'Show token'}
-              >
-                {isTokenVisible ? 'Hide' : 'Show'}
-              </button>
-            </div>
-            <div className="token-actions">
-              <button type="submit" className="token-button primary">
-                Save token
-              </button>
-              <button
-                type="button"
-                className="token-button secondary"
-                onClick={handleTokenClear}
-                disabled={!backendApiToken && !tokenInput}
-              >
-                Clear
-              </button>
-            </div>
-          </form>
-          {backendApiToken && (
+          <div className="token-input-row">
+            <input
+              type={isApiTokenVisible ? 'text' : 'password'}
+              className="token-input"
+              value={apiToken ?? ''}
+              readOnly
+              placeholder={isApiTokenBusy ? 'Loading API token…' : 'Load API token to display'}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              className="token-toggle"
+              onClick={handleToggleApiTokenVisibility}
+              aria-label={isApiTokenVisible ? 'Hide API token' : 'Show API token'}
+              disabled={!apiToken}
+            >
+              {isApiTokenVisible ? 'Hide' : 'Show'}
+            </button>
+          </div>
+          <div className="token-actions">
+            <button
+              type="button"
+              className="token-button primary"
+              onClick={handleFetchApiToken}
+              disabled={isFetchingApiToken}
+            >
+              {isFetchingApiToken ? 'Loading…' : 'Refresh token'}
+            </button>
+            <button
+              type="button"
+              className="token-button danger"
+              onClick={handleRotateApiToken}
+              disabled={isApiTokenBusy}
+            >
+              {isRotatingApiToken ? 'Rotating…' : 'Rotate token'}
+            </button>
+          </div>
+          {apiToken && (
             <div className="token-preview">
-              <span className="token-preview-label">Preview:</span>
-              <span className="token-preview-value">
-                {backendApiToken.length > 12
-                  ? `${backendApiToken.slice(0, 6)}…${backendApiToken.slice(-6)}`
-                  : backendApiToken}
-              </span>
-              <span className="token-preview-length">({backendApiToken.length} chars)</span>
+              <span className="token-preview-label">Length:</span>
+              <span className="token-preview-length">{apiToken.length} chars</span>
             </div>
           )}
-          {tokenFeedback && <div className="token-feedback">{tokenFeedback}</div>}
+          {apiTokenFeedback && (
+            <div className={`token-feedback token-feedback--${apiTokenFeedback.tone}`}>
+              {apiTokenFeedback.message}
+            </div>
+          )}
         </section>
 
         {/* Action Cards Section */}
@@ -296,7 +405,6 @@ const Dashboard: React.FC = () => {
       {showUnfamiliarLogin && (
         <UnfamiliarLoginPage
           accessToken={accessToken}
-          backendApiToken={backendApiToken}
           onClose={() => setShowUnfamiliarLogin(false)}
         />
       )}

--- a/frontend/src/components/UnfamiliarLoginPage.tsx
+++ b/frontend/src/components/UnfamiliarLoginPage.tsx
@@ -5,10 +5,12 @@ import type { Map as MaplibreMap } from 'maplibre-gl';
 import { LngLatBounds } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './UnfamiliarLoginPage.css';
+import { buildBearerToken, resolveApiBaseUrl } from '../utils/apiBaseUrl';
+
+type LayerProps = React.ComponentProps<typeof Layer>;
 
 interface UnfamiliarLoginPageProps {
   accessToken?: string | null;
-  backendApiToken?: string | null;
   onClose: () => void;
 }
 
@@ -290,40 +292,43 @@ const formatTimestamp = (timestamp: string): string => {
 };
 
 const transformEvents = (rawEvents: RawIdentityEvent[]): SignInEvent[] => {
-  return rawEvents
-    .map((raw, index) => {
-      const timestamp = getFirstTimestamp(raw);
-      const ipAddress = getFirstString(raw, IP_ADDRESS_KEYS);
-      const protocol = getFirstString(raw, PROTOCOL_KEYS);
-      const status = getFirstString(raw, STATUS_KEYS);
-      const displayLocation = buildDisplayLocation(raw);
-      const explicitLatitude = getFirstNumber(raw, LATITUDE_KEYS);
-      const explicitLongitude = getFirstNumber(raw, LONGITUDE_KEYS);
-      const coordinateResolution = resolveCoordinates(raw, displayLocation, explicitLatitude, explicitLongitude);
-      const latitude = explicitLatitude ?? coordinateResolution.latitude;
-      const longitude = explicitLongitude ?? coordinateResolution.longitude;
-      const idCandidate =
-        getFirstString(raw, ['EventId', 'Id', 'ActivityId', 'LogonId']) ??
-        `${timestamp ?? 'event'}-${index}`;
+  const events: SignInEvent[] = [];
 
-      if (!timestamp) {
-        return null;
-      }
+  rawEvents.forEach((raw, index) => {
+    const timestamp = getFirstTimestamp(raw);
+    if (!timestamp) {
+      return;
+    }
 
-      return {
-        id: idCandidate,
-        timestamp,
-        displayLocation: coordinateResolution.labelOverride ?? displayLocation,
-        ipAddress: ipAddress ?? undefined,
-        latitude,
-        longitude,
-        protocol: protocol ?? undefined,
-        status: status ?? undefined,
-        raw
-      } satisfies SignInEvent;
-    })
-    .filter((event): event is SignInEvent => event !== null)
-    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    const ipAddress = getFirstString(raw, IP_ADDRESS_KEYS);
+    const protocol = getFirstString(raw, PROTOCOL_KEYS);
+    const status = getFirstString(raw, STATUS_KEYS);
+    const displayLocation = buildDisplayLocation(raw);
+    const explicitLatitude = getFirstNumber(raw, LATITUDE_KEYS);
+    const explicitLongitude = getFirstNumber(raw, LONGITUDE_KEYS);
+    const coordinateResolution = resolveCoordinates(raw, displayLocation, explicitLatitude, explicitLongitude);
+    const latitude = explicitLatitude ?? coordinateResolution.latitude;
+    const longitude = explicitLongitude ?? coordinateResolution.longitude;
+    const idCandidate =
+      getFirstString(raw, ['EventId', 'Id', 'ActivityId', 'LogonId']) ??
+      `${timestamp}-${index}`;
+
+    const event: SignInEvent = {
+      id: idCandidate,
+      timestamp,
+      displayLocation: coordinateResolution.labelOverride ?? displayLocation,
+      ipAddress: ipAddress ?? undefined,
+      latitude,
+      longitude,
+      protocol: protocol ?? undefined,
+      status: status ?? undefined,
+      raw
+    };
+
+    events.push(event);
+  });
+
+  return events.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 };
 
 const buildGeoJson = (events: SignInEvent[]): FeatureCollection<Point> => {
@@ -349,25 +354,7 @@ const buildGeoJson = (events: SignInEvent[]): FeatureCollection<Point> => {
   };
 };
 
-const resolveApiBaseUrl = (): string => {
-  const explicit = import.meta.env.VITE_API_BASE_URL;
-  if (typeof explicit === 'string' && explicit.trim()) {
-    return explicit.trim().replace(/\/$/, '');
-  }
-
-  if (typeof window !== 'undefined') {
-    const origin = window.location.origin;
-    if (origin.includes('localhost')) {
-      return 'http://localhost:6081';
-    }
-    return origin.replace(/\/$/, '');
-  }
-
-  return 'http://localhost:6081';
-};
-
-
-const locationLayer: Layer = {
+const locationLayer: LayerProps = {
   id: 'identity-events',
   type: 'circle',
   paint: {
@@ -389,7 +376,7 @@ const locationLayer: Layer = {
 
 const DEFAULT_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
 
-const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, backendApiToken, onClose }) => {
+const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, onClose }) => {
   const [username, setUsername] = useState('');
   const [lookback, setLookback] = useState('7d');
   const [events, setEvents] = useState<SignInEvent[]>([]);
@@ -400,15 +387,10 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
   const [activeLookback, setActiveLookback] = useState<string>('7d');
 
   const effectiveAuthToken = useMemo(() => {
-    const manualToken = backendApiToken?.trim();
-    if (manualToken) {
-      return manualToken;
-    }
     const azureToken = accessToken?.trim();
     return azureToken && azureToken.length > 0 ? azureToken : null;
-  }, [backendApiToken, accessToken]);
+  }, [accessToken]);
 
-  const isUsingBackendToken = Boolean(backendApiToken?.trim());
 
   const mapRef = useRef<MapRef | null>(null);
 
@@ -473,7 +455,7 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
       return;
     }
     if (!effectiveAuthToken) {
-      setError('API authorization token missing. Save a backend token on the dashboard before fetching.');
+      setError('API authorization token missing. Please sign in again.');
       return;
     }
 
@@ -486,12 +468,10 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
       const endpoint = `${baseUrl}/graph/v1.0/identitylogonevents/${encodeURIComponent(targetUser)}`;
       const url = windowParam ? `${endpoint}?lookback=${encodeURIComponent(windowParam)}` : endpoint;
 
-      const tokenForHeader = /^Bearer\s+/i.test(effectiveAuthToken) ? effectiveAuthToken : `Bearer ${effectiveAuthToken}`;
-
       const response = await fetch(url, {
         method: 'GET',
         headers: {
-          Authorization: tokenForHeader,
+          Authorization: buildBearerToken(effectiveAuthToken),
           'Content-Type': 'application/json'
         }
       });
@@ -555,10 +535,8 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
         <form className="signin-controls" onSubmit={handleSubmit}>
           <div className={`token-status-banner ${effectiveAuthToken ? 'ready' : 'missing'}`}>
             {effectiveAuthToken
-              ? isUsingBackendToken
-                ? 'Using backend API token saved on the dashboard.'
-                : 'Using Azure AD access token.'
-              : 'No API token available. Save one on the dashboard to continue.'}
+              ? 'Using Azure AD access token.'
+              : 'No API token available. Please sign in again to continue.'}
           </div>
           <div className="input-group">
             <label htmlFor="signin-username">User Principal Name</label>

--- a/frontend/src/utils/apiBaseUrl.ts
+++ b/frontend/src/utils/apiBaseUrl.ts
@@ -1,0 +1,24 @@
+export const resolveApiBaseUrl = (): string => {
+  const explicit = import.meta.env.VITE_API_BASE_URL;
+  if (typeof explicit === 'string' && explicit.trim()) {
+    return explicit.trim().replace(/\/$/, '');
+  }
+
+  if (typeof window !== 'undefined') {
+    const origin = window.location.origin;
+    if (origin.includes('localhost')) {
+      return 'http://localhost:6081';
+    }
+    return origin.replace(/\/$/, '');
+  }
+
+  return 'http://localhost:6081';
+};
+
+export const buildBearerToken = (token: string): string => {
+  const trimmed = token.trim();
+  if (/^Bearer\s+/i.test(trimmed)) {
+    return trimmed;
+  }
+  return `Bearer ${trimmed}`;
+};


### PR DESCRIPTION
## Summary
- remove the manual backend token storage form from the dashboard and replace it with controls that fetch, rotate and reveal the user API token via Azure-authenticated requests
- surface API token status and feedback with updated styling while keeping the token hidden until requested, and add reusable helpers for building API URLs and bearer headers
- update the unfamiliar login modal to rely solely on the signed-in user's access token when requesting activity data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6903ba0af6ec832cb18a4ad5871ecc37