### PR TITLE
Fix Map component import alias in UnfamiliarLoginPage

### DIFF
--- a/frontend/src/components/UnfamiliarLoginPage.tsx
+++ b/frontend/src/components/UnfamiliarLoginPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Map, { Layer, MapRef, Popup, Source } from 'react-map-gl/maplibre';
+import MapComponent, { Layer, MapRef, Popup, Source } from 'react-map-gl/maplibre';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { LngLatBounds } from 'maplibre-gl';
@@ -802,7 +802,7 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
 
         <section className="signin-content">
           <div className="globe-panel">
-            <Map
+            <MapComponent
               ref={mapRef}
               initialViewState={DEFAULT_VIEW}
               mapStyle={DEFAULT_STYLE}
@@ -845,7 +845,7 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
                     </div>
                   </Popup>
                 )}
-            </Map>
+            </MapComponent>
             {activeUser && events.length > 0 && (
               <div className="globe-caption">
                 Highlighting sign-ins for <strong>{activeUser}</strong>


### PR DESCRIPTION
## Summary
- alias the `react-map-gl` Map component to avoid shadowing the built-in `Map` constructor
- update JSX usage to use the new alias

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903baec90b0832caa5efa38ea7fa745