### PR TITLE
Add context menu for sign-in map interactions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.25.1.tgz",
       "integrity": "sha512-kAdOSNjvMbeBmEyd5WnddGmIpKCbAAGj4Gg/1iURtF+nHmIfS0+QUBBO3uaHl7CBB2R1SEAbpOgxycEwrHOkFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.13.0"
       },
@@ -94,7 +93,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1490,7 +1488,6 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1564,7 +1561,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1815,7 +1811,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1971,7 +1966,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2242,7 +2236,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3038,7 +3031,6 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.9.0.tgz",
       "integrity": "sha512-YxW9glb/YrDXGDhqy1u+aG113+L86ttAUpTd6sCkGHyUKMXOX8qbGHJQVqxOczy+4CtRKnqcCfSura2MzB0nQA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -3404,7 +3396,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3417,7 +3408,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3850,7 +3840,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3936,7 +3925,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/UnfamiliarLoginPage.css
+++ b/frontend/src/components/UnfamiliarLoginPage.css
@@ -359,6 +359,81 @@
   word-break: break-word;
 }
 
+.signin-context-menu {
+  position: fixed;
+  z-index: 1200;
+  min-width: 200px;
+  max-width: 260px;
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 14px;
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 10px 0 8px 0;
+  animation: context-menu-pop 0.14s ease-out;
+}
+
+.signin-context-menu__meta {
+  display: flex;
+  flex-direction: column;
+  padding: 0 16px 8px 16px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+  gap: 2px;
+}
+
+.signin-context-menu__location {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.signin-context-menu__timestamp {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.signin-context-menu__action,
+.signin-context-menu__dismiss {
+  width: 100%;
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 10px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.signin-context-menu__action {
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.signin-context-menu__action:hover {
+  background: rgba(129, 140, 248, 0.12);
+}
+
+.signin-context-menu__dismiss {
+  color: #475569;
+}
+
+.signin-context-menu__dismiss:hover {
+  background: rgba(148, 163, 184, 0.14);
+}
+
+@keyframes context-menu-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .raw-event-details summary {
   cursor: pointer;
   font-size: 13px;

--- a/frontend/src/components/UnfamiliarLoginPage.tsx
+++ b/frontend/src/components/UnfamiliarLoginPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import MapComponent, { Layer, MapRef, Popup, Source } from 'react-map-gl/maplibre';
+import type { MapLayerMouseEvent } from 'react-map-gl/maplibre';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { LngLatBounds } from 'maplibre-gl';
@@ -27,6 +28,15 @@ interface SignInEvent {
   status?: string;
   geo?: GeoLookupResult;
   raw: RawIdentityEvent;
+}
+
+interface ContextMenuState {
+  eventId: string;
+  position: {
+    x: number;
+    y: number;
+  };
+  source: 'map' | 'timeline';
 }
 
 interface IdentityLogonResponse {
@@ -399,8 +409,10 @@ const buildGeoJson = (events: SignInEvent[]): FeatureCollection<Point> => {
   };
 };
 
+const LOCATION_LAYER_ID = 'identity-events';
+
 const locationLayer: LayerProps = {
-  id: 'identity-events',
+  id: LOCATION_LAYER_ID,
   type: 'circle',
   paint: {
     'circle-radius': [
@@ -430,6 +442,7 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [activeUser, setActiveUser] = useState<string>('');
   const [activeLookback, setActiveLookback] = useState<string>('7d');
+  const [contextMenuState, setContextMenuState] = useState<ContextMenuState | null>(null);
   const geolocationCacheRef = useRef<Map<string, GeoLookupResult>>(new Map());
 
   const effectiveAuthToken = useMemo(() => {
@@ -455,6 +468,66 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
     () => (selectedEvent ? JSON.stringify(selectedEvent.raw, null, 2) : ''),
     [selectedEvent]
   );
+
+  const contextMenuEvent = useMemo(
+    () =>
+      contextMenuState ? events.find(event => event.id === contextMenuState.eventId) ?? null : null,
+    [contextMenuState, events]
+  );
+
+  const closeContextMenu = useCallback(() => {
+    setContextMenuState(null);
+  }, []);
+
+  const openContextMenu = useCallback(
+    (eventId: string, clientX: number, clientY: number, source: ContextMenuState['source']) => {
+      const estimatedWidth = 220;
+      const estimatedHeight = 96;
+
+      let x = clientX;
+      let y = clientY;
+
+      if (typeof window !== 'undefined') {
+        x = Math.min(clientX, window.innerWidth - estimatedWidth);
+        y = Math.min(clientY, window.innerHeight - estimatedHeight);
+      }
+
+      setContextMenuState({
+        eventId,
+        position: { x, y },
+        source
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!contextMenuState) {
+      return;
+    }
+
+    const handleDismiss = () => {
+      setContextMenuState(null);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setContextMenuState(null);
+      }
+    };
+
+    window.addEventListener('click', handleDismiss);
+    window.addEventListener('scroll', handleDismiss, true);
+    window.addEventListener('resize', handleDismiss);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('click', handleDismiss);
+      window.removeEventListener('scroll', handleDismiss, true);
+      window.removeEventListener('resize', handleDismiss);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [contextMenuState]);
 
   const fitMapToEvents = useCallback(
     (map: MaplibreMap, targetEvents: SignInEvent[]) => {
@@ -498,6 +571,48 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
       });
     }
   };
+
+  const handleTimelineContextMenu = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    targetEvent: SignInEvent
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    openContextMenu(targetEvent.id, event.clientX, event.clientY, 'timeline');
+  };
+
+  const handleMapContextMenu = useCallback(
+    (event: MapLayerMouseEvent) => {
+      const originalEvent = event.originalEvent as MouseEvent | undefined;
+      if (originalEvent) {
+        originalEvent.preventDefault();
+        originalEvent.stopPropagation();
+      }
+
+      const feature = event.features?.[0];
+      const featureId = feature?.properties?.id;
+
+      if (featureId === null || featureId === undefined) {
+        closeContextMenu();
+        return;
+      }
+
+      const clientX = originalEvent?.clientX ?? event.point.x;
+      const clientY = originalEvent?.clientY ?? event.point.y;
+
+      openContextMenu(String(featureId), clientX, clientY, 'map');
+    },
+    [closeContextMenu, openContextMenu]
+  );
+
+  const handleContextMenuDetails = useCallback(() => {
+    if (!contextMenuEvent) {
+      return;
+    }
+
+    handleSelectEvent(contextMenuEvent);
+    closeContextMenu();
+  }, [closeContextMenu, contextMenuEvent]);
 
   const resolveIpGeolocation = useCallback(
     async (ip: string): Promise<GeoLookupResult> => {
@@ -789,6 +904,8 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
               scrollZoom
               dragPan
               attributionControl={false}
+              interactiveLayerIds={[LOCATION_LAYER_ID]}
+              onContextMenu={handleMapContextMenu}
             >
               <Source id="identity-events-source" type="geojson" data={geoJson}>
                 <Layer {...locationLayer} />
@@ -858,6 +975,7 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
                 <button
                   key={event.id}
                   onClick={() => handleSelectEvent(event)}
+                  onContextMenu={mouseEvent => handleTimelineContextMenu(mouseEvent, event)}
                   className={`timeline-item${event.id === selectedEventId ? ' active' : ''}`}
                   type="button"
                 >
@@ -955,6 +1073,26 @@ const UnfamiliarLoginPage: React.FC<UnfamiliarLoginPageProps> = ({ accessToken, 
             )}
           </aside>
         </section>
+        {contextMenuState && contextMenuEvent && (
+          <div
+            className="signin-context-menu"
+            role="menu"
+            style={{ left: `${contextMenuState.position.x}px`, top: `${contextMenuState.position.y}px` }}
+          >
+            <div className="signin-context-menu__meta" aria-hidden="true">
+              <span className="signin-context-menu__location">{contextMenuEvent.displayLocation}</span>
+              <span className="signin-context-menu__timestamp">
+                {formatTimestamp(contextMenuEvent.timestamp)}
+              </span>
+            </div>
+            <button type="button" onClick={handleContextMenuDetails} className="signin-context-menu__action">
+              View details
+            </button>
+            <button type="button" onClick={closeContextMenu} className="signin-context-menu__dismiss">
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add contextual menu state and handlers so right-clicking map points or timeline entries exposes a details shortcut
- configure the globe map layer for hit testing and present menu metadata alongside view/cancel actions
- style the contextual menu to match the existing modal design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6903c1d35490832c92a98285b113caff