### PR TITLE
Embed fetched Swagger spec to avoid modal CORS errors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.25.1.tgz",
       "integrity": "sha512-kAdOSNjvMbeBmEyd5WnddGmIpKCbAAGj4Gg/1iURtF+nHmIfS0+QUBBO3uaHl7CBB2R1SEAbpOgxycEwrHOkFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.13.0"
       },
@@ -94,7 +93,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1490,7 +1488,6 @@
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1564,7 +1561,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1815,7 +1811,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1971,7 +1966,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2242,7 +2236,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3038,7 +3031,6 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.9.0.tgz",
       "integrity": "sha512-YxW9glb/YrDXGDhqy1u+aG113+L86ttAUpTd6sCkGHyUKMXOX8qbGHJQVqxOczy+4CtRKnqcCfSura2MzB0nQA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -3404,7 +3396,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3417,7 +3408,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3850,7 +3840,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3936,7 +3925,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/SwaggerDocsModal.css
+++ b/frontend/src/components/SwaggerDocsModal.css
@@ -102,6 +102,23 @@
   border: none;
 }
 
+.swagger-status {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  text-align: center;
+  color: #1e293b;
+  font-size: 0.95rem;
+  background: linear-gradient(145deg, rgba(248, 250, 252, 0.95), rgba(226, 232, 240, 0.7));
+}
+
+.swagger-status p {
+  margin: 0;
+  max-width: 28rem;
+}
+
 @media (max-width: 768px) {
   .swagger-modal-content {
     padding: 0;

--- a/frontend/src/components/SwaggerDocsModal.tsx
+++ b/frontend/src/components/SwaggerDocsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import './SwaggerDocsModal.css';
 
 interface SwaggerDocsModalProps {
@@ -9,11 +9,46 @@ interface SwaggerDocsModalProps {
 const SWAGGER_SPEC_URL = 'https://api.security.ait.dtu.dk/myview/swagger/?format=openapi';
 
 const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClose }) => {
-  const swaggerHtmlDocument = useMemo(() => {
-    const encodedSpecUrl = JSON.stringify(SWAGGER_SPEC_URL);
-    const encodedToken = accessToken ? JSON.stringify(accessToken) : 'null';
+  const [swaggerHtmlDocument, setSwaggerHtmlDocument] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-    return `<!DOCTYPE html>
+  useEffect(() => {
+    let isActive = true;
+
+    const fetchSwaggerSpec = async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const headers: HeadersInit = {
+          Accept: 'application/json',
+        };
+
+        if (accessToken) {
+          headers.Authorization = `Bearer ${accessToken}`;
+        }
+
+        const response = await fetch(SWAGGER_SPEC_URL, {
+          method: 'GET',
+          headers,
+          credentials: 'include',
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to load Swagger specification (${response.status})`);
+        }
+
+        const swaggerSpec = await response.json();
+
+        if (!isActive) {
+          return;
+        }
+
+        const serializedSpec = JSON.stringify(swaggerSpec).replace(/</g, '\\u003c');
+        const encodedToken = accessToken ? JSON.stringify(accessToken) : 'null';
+
+        const htmlDocument = `<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -31,11 +66,11 @@ const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClos
     <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
     <script>
       (function () {
-        const swaggerSpecUrl = ${encodedSpecUrl};
+        const swaggerSpec = ${serializedSpec};
         const accessToken = ${encodedToken};
 
         window.ui = SwaggerUIBundle({
-          url: swaggerSpecUrl,
+          spec: swaggerSpec,
           dom_id: '#swagger-ui',
           presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
           layout: 'BaseLayout',
@@ -52,6 +87,32 @@ const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClos
     </script>
   </body>
 </html>`;
+
+        setSwaggerHtmlDocument(htmlDocument);
+      } catch (error: unknown) {
+        if (!isActive) {
+          return;
+        }
+
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unable to load the Swagger documentation at this time.';
+
+        setErrorMessage(message);
+        setSwaggerHtmlDocument(null);
+      } finally {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchSwaggerSpec();
+
+    return () => {
+      isActive = false;
+    };
   }, [accessToken]);
 
   const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -93,12 +154,24 @@ const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClos
           </div>
         </header>
         <div className="swagger-iframe-container">
-          <iframe
-            srcDoc={swaggerHtmlDocument}
-            title="Backend Swagger Documentation"
-            className="swagger-iframe"
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
-          />
+          {isLoading && (
+            <div className="swagger-status">
+              <p>Loading Swagger documentation…</p>
+            </div>
+          )}
+          {!isLoading && errorMessage && (
+            <div className="swagger-status">
+              <p>{errorMessage}</p>
+            </div>
+          )}
+          {!isLoading && !errorMessage && swaggerHtmlDocument && (
+            <iframe
+              srcDoc={swaggerHtmlDocument}
+              title="Backend Swagger Documentation"
+              className="swagger-iframe"
+              sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+            />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fetch the Swagger specification within the React app and embed it into the modal HTML to avoid cross-origin loading failures
- keep bearer token forwarding for Swagger requests while adding loading and error states around the embedded iframe
- style the placeholder state shown while the Swagger document loads or fails

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6903c490704c832caa75e7254c132a8f