### PR TITLE
Fix limiter migration transaction handling

### DIFF
--- a/backend/app-main/myview/migrations/0010_move_no_limit_to_limiter_type.py
+++ b/backend/app-main/myview/migrations/0010_move_no_limit_to_limiter_type.py
@@ -39,6 +39,12 @@ class Migration(migrations.Migration):
         ("myview", "0009_mfaresetrecord"),
     ]
 
+    # Dropping the ``no_limit`` column can conflict with pending deferrable
+    # trigger events on PostgreSQL when the migration is wrapped in a single
+    # transaction.  Running the operations non-atomically lets Postgres commit
+    # the previous trigger work before issuing the ``ALTER TABLE`` statement.
+    atomic = False
+
     operations = [
         migrations.RunPython(forwards, backwards),
         migrations.RemoveField(


### PR DESCRIPTION
## Summary
- make the `0010_move_no_limit_to_limiter_type` migration non-atomic so PostgreSQL can clear pending trigger events before dropping the `no_limit` column
- document the rationale inside the migration for future maintainers

## Testing
- `cd backend/app-main && python -m py_compile myview/migrations/0010_move_no_limit_to_limiter_type.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af3f4a31c832cafda3f136c3bc9d0)