### PR TITLE
Require env-defined networks and add preview guide

### DIFF
--- a/backend/docker-compose.coolify.yaml
+++ b/backend/docker-compose.coolify.yaml
@@ -57,7 +57,7 @@ services:
       - "traefik.http.routers.${TRAEFIK_ROUTER_NAME:-api_security}.tls.domains[0].main=${SERVICE_FQDN_WEB:-api.security.ait.dtu.dk}"
       - "traefik.http.routers.${TRAEFIK_ROUTER_NAME:-api_security}.tls.certresolver="
       - "traefik.http.services.${TRAEFIK_SERVICE_NAME:-api_security}.loadbalancer.server.port=8121"
-      - "traefik.docker.network=${TRAEFIK_NETWORK:-api-security-proxy}"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:?TRAEFIK_NETWORK must be set}"
 
   db:
     image: postgres:16
@@ -94,9 +94,9 @@ volumes:
 networks:
   internal:
     driver: bridge
-    name: ${DOCKER_NETWORK:-api-security-internal}
+    name: ${DOCKER_NETWORK:?DOCKER_NETWORK must be set}
   proxy:
     driver: bridge
-    name: ${TRAEFIK_NETWORK:-api-security-proxy}
+    name: ${TRAEFIK_NETWORK:?TRAEFIK_NETWORK must be set}
     attachable: true
-    external: ${TRAEFIK_NETWORK_EXTERNAL:-false}
+    external: ${TRAEFIK_NETWORK_EXTERNAL:?TRAEFIK_NETWORK_EXTERNAL must be set}

--- a/backend/docs/preview-deployment-guide.md
+++ b/backend/docs/preview-deployment-guide.md
@@ -1,0 +1,75 @@
+# Preview Deployment Next to Production
+
+This guide explains how to run a preview deployment alongside production using the same Docker environment. It relies on environment variables supplied via a `.env` file so the compose stack never falls back to baked-in network names.
+
+## 1. Prerequisites
+- Docker and Docker Compose installed.
+- Access to the production `docker-compose.coolify.yaml` file in this repository.
+- A `.env` file that defines network names, Traefik configuration, database credentials, and Django secrets for each deployment.
+
+## 2. Define environment variables
+Create two `.env` files—one for production and one for preview. The key requirement is that network names come from the `.env` file (no defaults in the compose file).
+
+Example `production.env`:
+```
+DOCKER_NETWORK=api-security-internal
+TRAEFIK_NETWORK=api-security-proxy
+TRAEFIK_NETWORK_EXTERNAL=true
+TRAEFIK_ROUTER_NAME=api_security
+TRAEFIK_SERVICE_NAME=api_security
+SERVICE_FQDN_WEB=api.security.ait.dtu.dk
+SERVICE_URL_WEB=https://api.security.ait.dtu.dk
+DJANGO_SECRET=...prod-secret...
+POSTGRES_PASSWORD=...prod-password...
+```
+
+Example `preview.env` (use unique hostnames and router names):
+```
+DOCKER_NETWORK=api-security-internal
+TRAEFIK_NETWORK=api-security-proxy
+TRAEFIK_NETWORK_EXTERNAL=true
+TRAEFIK_ROUTER_NAME=api_security_preview
+TRAEFIK_SERVICE_NAME=api_security_preview
+SERVICE_FQDN_WEB=preview.api.security.ait.dtu.dk
+SERVICE_URL_WEB=https://preview.api.security.ait.dtu.dk
+DJANGO_ALLOWED_HOSTS=preview.api.security.ait.dtu.dk
+DJANGO_CSRF_TRUSTED_ORIGINS=https://preview.api.security.ait.dtu.dk
+AZURE_REDIRECT_URI=https://preview.api.security.ait.dtu.dk/auth/callback
+DJANGO_SECRET=...preview-secret...
+POSTGRES_PASSWORD=...preview-password...
+POSTGRES_DB=app_preview
+POSTGRES_USER=app_preview
+CACHE_URL=redis://redis:6379/1
+```
+
+> The shared network names allow both stacks to communicate with the Traefik proxy, while distinct router/service names and hostnames keep routing separate.
+
+## 3. Start production
+From the `backend` directory, run:
+```
+cp production.env .env
+docker compose -f docker-compose.coolify.yaml up -d
+```
+
+## 4. Start preview alongside production
+Use the preview environment file without stopping production:
+```
+cp preview.env .env
+docker compose -p api-security-preview -f docker-compose.coolify.yaml up -d
+```
+
+Notes:
+- The `-p` flag assigns a unique project name so containers do not clash with the production ones.
+- Ensure the preview database credentials point to a separate database/schema to avoid data overlap.
+
+## 5. Traefik routing
+Traefik uses values from `.env`:
+- `TRAEFIK_NETWORK` must match the external proxy network name.
+- `TRAEFIK_ROUTER_NAME` and `TRAEFIK_SERVICE_NAME` must be unique per deployment (production vs. preview).
+- `SERVICE_FQDN_WEB` sets the hostname rule; ensure DNS points the preview hostname to the proxy.
+
+## 6. Verifying both stacks
+- Access production at `https://api.security.ait.dtu.dk`.
+- Access preview at `https://preview.api.security.ait.dtu.dk`.
+
+Use `docker compose ls` to confirm both projects are running and `docker compose logs -f` (with the correct `-p` value) to inspect each stack.


### PR DESCRIPTION
## Summary
- require environment-provided network values for the compose stack instead of defaulting to built-in names
- add documentation describing how to run a preview deployment alongside production using environment files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244fda768c832cb93f09ff6b6cc754)