### PR TITLE
Align HIBP URL patterns with upstream API paths

### DIFF
--- a/backend/app-main/hibp/urls.py
+++ b/backend/app-main/hibp/urls.py
@@ -3,21 +3,24 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("hibp/v3/subscribeddomains", views.SubscriptionDomainsView.as_view()),
-    path("hibp/v3/subscription/status", views.SubscriptionStatusView.as_view()),
-    path("hibp/v3/breacheddomain/<str:domain>", views.BreachedDomainView.as_view()),
-    path("hibp/v3/dataclasses", views.DataClassesView.as_view()),
-    path("hibp/v3/breachedaccount/<str:account>", views.BreachedAccountView.as_view()),
-    path("hibp/v3/breaches", views.AllBreachesView.as_view()),
-    path("hibp/v3/breach/<str:name>", views.SingleBreachView.as_view()),
-    path("hibp/v3/pasteaccount/<str:account>", views.PasteAccountView.as_view()),
+    path("hibp/api/v3/subscribeddomains", views.SubscriptionDomainsView.as_view()),
+    path("hibp/api/v3/subscription/status", views.SubscriptionStatusView.as_view()),
+    path("hibp/api/v3/breacheddomain/<str:domain>", views.BreachedDomainView.as_view()),
+    path("hibp/api/v3/dataclasses", views.DataClassesView.as_view()),
+    path("hibp/api/v3/breachedaccount/<str:account>", views.BreachedAccountView.as_view()),
+    path("hibp/api/v3/breaches", views.AllBreachesView.as_view()),
+    path("hibp/api/v3/breach/<str:name>", views.SingleBreachView.as_view()),
+    path("hibp/api/v3/pasteaccount/<str:account>", views.PasteAccountView.as_view()),
     path(
-        "hibp/v3/stealerlogsbyemaildomain/<str:domain>",
+        "hibp/api/v3/stealerlogsbyemaildomain/<str:domain>",
         views.StealerLogsByEmailDomainView.as_view(),
     ),
-    path("hibp/v3/stealerlogsbyemail/<str:account>", views.StealerLogsByEmailView.as_view()),
     path(
-        "hibp/v3/stealerlogsbywebsitedomain/<str:domain>",
+        "hibp/api/v3/stealerlogsbyemail/<str:account>",
+        views.StealerLogsByEmailView.as_view(),
+    ),
+    path(
+        "hibp/api/v3/stealerlogsbywebsitedomain/<str:domain>",
         views.StealerLogsByWebsiteDomainView.as_view(),
     ),
     path("hibp/range/<str:prefix>", views.PwnedPasswordsRangeView.as_view()),


### PR DESCRIPTION
## Summary
- update HIBP URL patterns to include the upstream api/v3 path segments
- ensure local proxy endpoints mirror original HIBP signatures under the hibp namespace

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69245ee142b8832c80b6cca1bcbf7b0d)