### PR TITLE
Resolve dependency conflict between msal and cryptography

### DIFF
--- a/backend/app-main/requirements.txt
+++ b/backend/app-main/requirements.txt
@@ -40,7 +40,7 @@ MarkupSafe==3.0.3
 microsoft-kiota-abstractions==1.3.1
 microsoft-kiota-authentication-azure==1.0.0
 microsoft-kiota-http==1.3.1
-msal==1.27.0
+msal==1.34.0
 msal-extensions==1.1.0
 msgraph-core==1.0.0
 multidict==6.0.5


### PR DESCRIPTION
## Summary
- bump msal to 1.34.0 to align with cryptography 46.x and pyOpenSSL 25.x
- normalize requirements.txt formatting with a trailing newline

## Testing
- python -m pip install --no-cache-dir -r backend/app-main/requirements.txt

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a43a9798832ca9662ebe46cbe35f)