### PR TITLE
Ensure embedded Swagger UI loads while authenticated

### DIFF
--- a/frontend/src/components/SwaggerDocsModal.tsx
+++ b/frontend/src/components/SwaggerDocsModal.tsx
@@ -34,6 +34,7 @@ const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClos
         const response = await fetch(swaggerSpecUrl, {
           method: 'GET',
           headers,
+          credentials: 'include',
         });
 
         if (!response.ok) {
@@ -81,6 +82,7 @@ const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClos
           layout: 'BaseLayout',
           deepLinking: true,
           requestInterceptor: (req) => {
+            req.credentials = 'include';
             if (accessToken) {
               req.headers = req.headers || {};
               req.headers.Authorization = 'Bearer ' + accessToken;
@@ -122,6 +124,7 @@ const SwaggerDocsModal: React.FC<SwaggerDocsModalProps> = ({ accessToken, onClos
           layout: 'BaseLayout',
           deepLinking: true,
           requestInterceptor: (req) => {
+            req.credentials = 'include';
             if (accessToken) {
               req.headers = req.headers || {};
               req.headers.Authorization = 'Bearer ' + accessToken;


### PR DESCRIPTION
## Summary
- update the Swagger documentation modal to send credentials when fetching the OpenAPI schema
- ensure the embedded Swagger UI forwards credentials so authenticated requests succeed even in fallback mode

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6903d669e480832cbb5c4345097a2c95)