### PR TITLE
Handle missing tables in HIBP limiter sync

### DIFF
--- a/backend/app-main/hibp/apps.py
+++ b/backend/app-main/hibp/apps.py
@@ -2,7 +2,7 @@ import logging
 
 from django.apps import AppConfig
 from django.apps import apps as django_apps
-from django.db import OperationalError, ProgrammingError
+from django.db import DEFAULT_DB_ALIAS, OperationalError, ProgrammingError, connections
 from django.db.utils import ConnectionDoesNotExist
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,29 @@ class HibpConfig(AppConfig):
 
     def _ensure_endpoint_limiters(self) -> None:
         """Assign AD OU limiter type to all configured HIBP endpoints."""
+
+        try:
+            connection = connections[DEFAULT_DB_ALIAS]
+            with connection.cursor() as cursor:
+                table_names = set(connection.introspection.table_names(cursor))
+        except (OperationalError, ProgrammingError, ConnectionDoesNotExist):
+            logger.info("Database not ready for HIBP limiter sync; will rely on signals")
+            return
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "Unexpected error while checking database readiness for HIBP limiter sync"
+            )
+            return
+
+        required_tables = {
+            "myview_limitertype",
+            "myview_endpoint",
+            "django_content_type",
+        }
+
+        if not required_tables.issubset(table_names):
+            logger.info("Database tables missing for HIBP limiter sync; will rely on signals")
+            return
 
         try:
             Endpoint = django_apps.get_model("myview", "Endpoint")

--- a/backend/app-main/hibp/tests/test_apps.py
+++ b/backend/app-main/hibp/tests/test_apps.py
@@ -1,0 +1,34 @@
+from importlib import import_module
+from unittest.mock import MagicMock, patch
+
+from django.db import DEFAULT_DB_ALIAS
+from django.test import SimpleTestCase
+
+from hibp.apps import HibpConfig
+
+
+class HibpAppsTests(SimpleTestCase):
+    def test_hibp_sync_skips_when_tables_missing(self):
+        app_module = import_module("hibp")
+        config = HibpConfig("hibp", app_module)
+
+        mock_connection = MagicMock()
+        mock_connection.introspection = MagicMock()
+        mock_connection.introspection.table_names.return_value = []
+
+        mock_cursor_cm = MagicMock()
+        mock_cursor_cm.__enter__.return_value = MagicMock()
+        mock_cursor_cm.__exit__.return_value = False
+        mock_connection.cursor.return_value = mock_cursor_cm
+
+        dummy_connections = {DEFAULT_DB_ALIAS: mock_connection}
+
+        with patch("hibp.apps.connections", dummy_connections), patch(
+            "hibp.apps.logger"
+        ) as mock_logger:
+            config._ensure_endpoint_limiters()
+
+        mock_logger.info.assert_called_with(
+            "Database tables missing for HIBP limiter sync; will rely on signals"
+        )
+        mock_connection.cursor.assert_called_once()


### PR DESCRIPTION
## Summary
- guard the HIBP limiter assignment against missing database tables before hitting the ORM
- add a unit test to confirm the limiter sync exits early when tables are absent

## Testing
- python manage.py test hibp.tests.test_apps.HibpAppsTests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a6bbe1bc832c85c678cb6c2b7c30)